### PR TITLE
Add FingerTree-like push_right, drop_left for performance; move out Empty variant

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "im_ternary_tree"
-version = "0.0.1-a8"
+version = "0.0.2-a1"
 edition = "2021"
 authors = ["jiyinyiyong <jiyinyiyong@gmail.com>"]
 license = "MIT"

--- a/benches/creating.rs
+++ b/benches/creating.rs
@@ -13,6 +13,16 @@ fn criterion_benchmark(c: &mut Criterion) {
     })
   });
 
+  c.bench_function("creating list disable balancing", |b| {
+    b.iter(|| {
+      let mut data = TernaryTreeList::Empty;
+
+      for idx in 0..1000 {
+        data = data.append(idx, true)
+      }
+    })
+  });
+
   c.bench_function("push_right list", |b| {
     b.iter(|| {
       let mut data = TernaryTreeList::Empty;
@@ -27,20 +37,10 @@ fn criterion_benchmark(c: &mut Criterion) {
     b.iter(|| {
       let mut data = TernaryTreeList::Empty;
 
+      // TODO overflowed
       for idx in 0..1000 {
         let pos = idx / 2;
         data = data.insert(pos, idx, false).unwrap()
-      }
-    })
-  });
-
-  c.bench_function("inserting in middle without balancing", |b| {
-    b.iter(|| {
-      let mut data = TernaryTreeList::Empty;
-
-      for idx in 0..1000 {
-        let pos = idx / 2;
-        data = data.insert(pos, idx, true).unwrap()
       }
     })
   });
@@ -49,8 +49,7 @@ fn criterion_benchmark(c: &mut Criterion) {
     let mut data = TernaryTreeList::Empty;
 
     for idx in 0..1000 {
-      let pos = idx / 2;
-      data = data.insert(pos, idx, false).unwrap()
+      data = data.push(idx);
     }
 
     b.iter(move || {
@@ -62,12 +61,59 @@ fn criterion_benchmark(c: &mut Criterion) {
     })
   });
 
+  c.bench_function("rest from push_right", |b| {
+    let mut data = TernaryTreeList::Empty;
+
+    for idx in 0..1000 {
+      data = data.push_right(idx);
+    }
+
+    b.iter(move || {
+      let mut d = data.to_owned();
+
+      while !d.is_empty() {
+        d = d.slice(1, d.len()).unwrap()
+      }
+    })
+  });
+
+  c.bench_function("drop-left", |b| {
+    let mut data = TernaryTreeList::Empty;
+
+    for idx in 0..1000 {
+      data = data.push(idx);
+    }
+
+    b.iter(move || {
+      let mut d = data.to_owned();
+
+      while d.len() > 1 {
+        d = d.drop_left()
+      }
+    })
+  });
+
+  c.bench_function("drop-left from push_right", |b| {
+    let mut data = TernaryTreeList::Empty;
+
+    for idx in 0..1000 {
+      data = data.push_right(idx);
+    }
+
+    b.iter(move || {
+      let mut d = data.to_owned();
+
+      while d.len() > 1 {
+        d = d.drop_left()
+      }
+    })
+  });
+
   c.bench_function("slice", |b| {
     let mut data = TernaryTreeList::Empty;
 
     for idx in 0..1000 {
-      let pos = idx / 2;
-      data = data.insert(pos, idx, false).unwrap()
+      data = data.push(idx)
     }
 
     b.iter(move || {

--- a/benches/creating.rs
+++ b/benches/creating.rs
@@ -13,6 +13,16 @@ fn criterion_benchmark(c: &mut Criterion) {
     })
   });
 
+  c.bench_function("push_right list", |b| {
+    b.iter(|| {
+      let mut data = TernaryTreeList::Empty;
+
+      for idx in 0..1000 {
+        data = data.push_right(idx)
+      }
+    })
+  });
+
   c.bench_function("inserting in middle", |b| {
     b.iter(|| {
       let mut data = TernaryTreeList::Empty;

--- a/examples/drop_left.rs
+++ b/examples/drop_left.rs
@@ -23,5 +23,18 @@ pub fn main() -> Result<(), String> {
     println!("{}", data4.format_inline());
   }
 
+  let mut data = TernaryTreeList::Empty;
+
+  for idx in 0..1000 {
+    data = data.push(idx)
+  }
+
+  let mut d = data.to_owned();
+
+  while d.len() > 1 {
+    d = d.drop_left();
+    println!("{}", d.format_inline());
+  }
+
   Ok(())
 }

--- a/examples/drop_left.rs
+++ b/examples/drop_left.rs
@@ -1,0 +1,27 @@
+use im_ternary_tree::TernaryTreeList;
+
+pub fn main() -> Result<(), String> {
+  let mut tree: TernaryTreeList<usize> = TernaryTreeList::Empty;
+
+  for idx in 0..60 {
+    tree = tree.push_right(idx);
+  }
+
+  for _ in 0..59 {
+    tree = tree.drop_left();
+    println!("{}", tree.format_inline());
+  }
+
+  let mut origin4: Vec<usize> = vec![];
+  for idx in 0..60 {
+    origin4.push(idx);
+  }
+  let mut data4 = TernaryTreeList::from(&origin4);
+
+  for _ in 0..59 {
+    data4 = data4.drop_left();
+    println!("{}", data4.format_inline());
+  }
+
+  Ok(())
+}

--- a/examples/push.rs
+++ b/examples/push.rs
@@ -1,7 +1,12 @@
 use im_ternary_tree::TernaryTreeList;
 
 pub fn main() -> Result<(), String> {
-  let tree = TernaryTreeList::new();
+  let mut tree: TernaryTreeList<usize> = TernaryTreeList::Empty;
+
+  for idx in 0..60 {
+    tree = tree.push_right(idx);
+    println!("{}", tree.format_inline());
+  }
 
   Ok(())
 }

--- a/examples/push.rs
+++ b/examples/push.rs
@@ -1,0 +1,7 @@
+use im_ternary_tree::TernaryTreeList;
+
+pub fn main() -> Result<(), String> {
+  let tree = TernaryTreeList::new();
+
+  Ok(())
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -32,13 +32,13 @@ pub enum TernaryTreeList<T> {
   Leaf(Arc<T>),
   Branch2 {
     size: usize,
-    depth: u8,
+    depth: u16,
     left: Arc<TernaryTreeList<T>>,
     middle: Arc<TernaryTreeList<T>>,
   },
   Branch3 {
     size: usize,
-    depth: u8,
+    depth: u16,
     left: Arc<TernaryTreeList<T>>,
     middle: Arc<TernaryTreeList<T>>,
     right: Arc<TernaryTreeList<T>>,
@@ -59,7 +59,7 @@ where
   T: Clone + Display + Eq + PartialEq + Debug + Ord + PartialOrd + Hash,
 {
   /// just get, will not compute recursively
-  pub fn get_depth(&self) -> u8 {
+  pub fn get_depth(&self) -> u16 {
     match self {
       Empty => 0,
       Leaf { .. } => 0,
@@ -1450,7 +1450,7 @@ where
 fn decide_parent_depth_2<T: Clone + Display + Eq + PartialEq + Debug + Ord + PartialOrd + Hash>(
   x0: &TernaryTreeList<T>,
   x1: &TernaryTreeList<T>,
-) -> u8 {
+) -> u16 {
   cmp::max(x0.get_depth(), x1.get_depth()) + 1
 }
 
@@ -1459,7 +1459,8 @@ fn decide_parent_depth_3<T: Clone + Display + Eq + PartialEq + Debug + Ord + Par
   x0: &TernaryTreeList<T>,
   x1: &TernaryTreeList<T>,
   x2: &TernaryTreeList<T>,
-) -> u8 {
+) -> u16 {
+  // println!("{} {} {}", x0.get_depth(), x1.get_depth(), x2.get_depth());
   cmp::max(cmp::max(x0.get_depth(), x1.get_depth()), x2.get_depth()) + 1
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -164,7 +164,7 @@ where
     match self {
       Empty => {
         if idx == 0 {
-          Ok(TernaryTreeList::Tree(TernaryTree::Leaf(Arc::new(item))))
+          Ok(TernaryTreeList::Tree(TernaryTree::Leaf(item)))
         } else {
           Err(String::from("inserting into empty, but index is not 0"))
         }
@@ -199,7 +199,7 @@ where
   }
   pub fn prepend(&self, item: T, disable_balancing: bool) -> Self {
     match self {
-      Empty => TernaryTreeList::Tree(TernaryTree::Leaf(Arc::new(item))),
+      Empty => TernaryTreeList::Tree(TernaryTree::Leaf(item)),
       Tree(t) => TernaryTreeList::Tree(t.prepend(item, disable_balancing)),
     }
   }
@@ -208,13 +208,13 @@ where
   }
   pub fn append(&self, item: T, disable_balancing: bool) -> Self {
     match self {
-      Empty => TernaryTreeList::Tree(TernaryTree::Leaf(Arc::new(item))),
+      Empty => TernaryTreeList::Tree(TernaryTree::Leaf(item)),
       Tree(t) => TernaryTreeList::Tree(t.append(item, disable_balancing)),
     }
   }
   pub fn push_right(&self, item: T) -> Self {
     match self {
-      Empty => TernaryTreeList::Tree(TernaryTree::Leaf(Arc::new(item))),
+      Empty => TernaryTreeList::Tree(TernaryTree::Leaf(item)),
       Tree(t) => TernaryTreeList::Tree(t.push_right(item)),
     }
   }
@@ -222,7 +222,13 @@ where
   pub fn drop_left(&self) -> Self {
     match self {
       Empty => TernaryTreeList::Empty,
-      Tree(t) => TernaryTreeList::Tree(t.drop_left()),
+      Tree(t) => {
+        if t.len() == 1 {
+          TernaryTreeList::Empty
+        } else {
+          TernaryTreeList::Tree(t.drop_left())
+        }
+      }
     }
   }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -144,6 +144,8 @@ where
   pub fn rest(&self) -> Result<Self, String> {
     if self.is_empty() {
       Err(String::from("calling rest on empty"))
+    } else if self.len() == 1 {
+      Ok(TernaryTreeList::Empty)
     } else {
       self.dissoc(0)
     }
@@ -151,6 +153,8 @@ where
   pub fn butlast(&self) -> Result<Self, String> {
     if self.is_empty() {
       Err(String::from("calling butlast on empty"))
+    } else if self.len() == 1 {
+      Ok(TernaryTreeList::Empty)
     } else {
       self.dissoc(self.len() - 1)
     }
@@ -244,6 +248,9 @@ where
   }
   // excludes value at end_idx, kept aligned with JS & Clojure
   pub fn slice(&self, start_idx: usize, end_idx: usize) -> Result<Self, String> {
+    if start_idx == end_idx {
+      return Ok(TernaryTreeList::Empty);
+    }
     match self {
       Empty => Err(String::from("empty")),
       Tree(t) => Ok(TernaryTreeList::Tree(t.slice(start_idx, end_idx)?)),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -13,10 +13,9 @@
 //! ```
 
 mod slice;
+mod tree;
 mod util;
 
-use std::cell::RefCell;
-use std::cmp;
 use std::cmp::Ordering;
 use std::fmt;
 use std::fmt::{Debug, Display};
@@ -24,32 +23,12 @@ use std::hash::{Hash, Hasher};
 use std::ops::Index;
 use std::sync::Arc;
 
-use util::{divide_ternary_sizes, rough_int_pow};
+pub use tree::TernaryTree;
 
 #[derive(Clone, Debug)]
 pub enum TernaryTreeList<T> {
   Empty,
-  Leaf(Arc<T>),
-  Branch2 {
-    size: usize,
-    depth: u16,
-    left: Arc<TernaryTreeList<T>>,
-    middle: Arc<TernaryTreeList<T>>,
-  },
-  Branch3 {
-    size: usize,
-    depth: u16,
-    left: Arc<TernaryTreeList<T>>,
-    middle: Arc<TernaryTreeList<T>>,
-    right: Arc<TernaryTreeList<T>>,
-  },
-}
-
-/// special mark for helping in simulating finger tree bahaviors to operate head tails
-#[derive(Debug)]
-pub enum FingerMark {
-  Main(i8),
-  Side(i8),
+  Tree(TernaryTree<T>),
 }
 
 use TernaryTreeList::*;
@@ -62,71 +41,21 @@ where
   pub fn get_depth(&self) -> u16 {
     match self {
       Empty => 0,
-      Leaf { .. } => 0,
-      Branch2 { depth, .. } => *depth,
-      Branch3 { depth, .. } => *depth,
+      Tree(t) => t.get_depth(),
     }
   }
 
   pub fn is_empty(&self) -> bool {
     match self {
       Empty => true,
-      Leaf { .. } => false,
-      Branch2 { size, .. } => *size == 0,
-      Branch3 { size, .. } => *size == 0,
+      Tree(_) => false,
     }
   }
 
   pub fn len(&self) -> usize {
     match self {
       Empty => 0,
-      Leaf { .. } => 1,
-      Branch2 { size, .. } => *size,
-      Branch3 { size, .. } => *size,
-    }
-  }
-
-  // make list again from existed
-  fn rebuild_list(size: usize, offset: usize, xs: &[TernaryTreeList<T>]) -> Self {
-    match size {
-      0 => Empty,
-      1 => xs[offset].to_owned(),
-      2 => {
-        let left = &xs[offset];
-        let middle = &xs[offset + 1];
-        Branch2 {
-          size: left.len() + middle.len(),
-          left: Arc::new(left.to_owned()),
-          middle: Arc::new(middle.to_owned()),
-          depth: decide_parent_depth_2(left, middle),
-        }
-      }
-      3 => {
-        let left = &xs[offset];
-        let middle = &xs[offset + 1];
-        let right = &xs[offset + 2];
-        Branch3 {
-          size: left.len() + middle.len() + right.len(),
-          left: Arc::new(left.to_owned()),
-          middle: Arc::new(middle.to_owned()),
-          right: Arc::new(right.to_owned()),
-          depth: decide_parent_depth_3(left, middle, right),
-        }
-      }
-      _ => {
-        let divided = divide_ternary_sizes(size);
-
-        let left = Self::rebuild_list(divided.0, offset, xs);
-        let middle = Self::rebuild_list(divided.1, offset + divided.0, xs);
-        let right = Self::rebuild_list(divided.2, offset + divided.0 + divided.1, xs);
-        Branch3 {
-          size: left.len() + middle.len() + right.len(),
-          depth: decide_parent_depth_3(&left, &middle, &right),
-          left: Arc::new(left),
-          middle: Arc::new(middle),
-          right: Arc::new(right),
-        }
-      }
+      Tree(t) => t.len(),
     }
   }
 
@@ -134,15 +63,7 @@ where
   pub fn format_inline(&self) -> String {
     match self {
       Empty => String::from("_"),
-      Leaf(value) => value.to_string(),
-      Branch2 { left, middle, .. } => {
-        // TODO maybe need more informations here
-        format!("({} {})", left.format_inline(), middle.format_inline())
-      }
-      Branch3 { left, middle, right, .. } => {
-        // TODO maybe need more informations here
-        format!("({} {} {})", left.format_inline(), middle.format_inline(), right.format_inline())
-      }
+      Tree(t) => t.format_inline(),
     }
   }
 
@@ -157,210 +78,40 @@ where
   pub fn find_index(&self, f: Arc<dyn Fn(&T) -> bool>) -> Option<i64> {
     match self {
       Empty => None,
-      Leaf(value) => {
-        if f(value) {
-          Some(0)
-        } else {
-          None
-        }
-      }
-
-      Branch2 { left, middle, .. } => {
-        if let Some(pos) = left.find_index(f.clone()) {
-          return Some(pos);
-        }
-
-        if let Some(pos) = middle.find_index(f.clone()) {
-          return Some(pos + left.len() as i64);
-        }
-
-        None
-      }
-
-      Branch3 { left, middle, right, .. } => {
-        if let Some(pos) = left.find_index(f.clone()) {
-          return Some(pos);
-        }
-
-        if let Some(pos) = middle.find_index(f.clone()) {
-          return Some(pos + left.len() as i64);
-        }
-
-        if let Some(pos) = right.find_index(f.clone()) {
-          return Some(pos + (left.len() as i64) + (middle.len() as i64));
-        }
-
-        None
-      }
+      Tree(t) => t.find_index(f),
     }
   }
 
   pub fn index_of(&self, item: &T) -> Option<usize> {
     match self {
       Empty => None,
-      Leaf(value) => {
-        if item == &**value {
-          Some(0)
-        } else {
-          None
-        }
-      }
-      Branch2 { left, middle, .. } => {
-        if let Some(pos) = left.index_of(item) {
-          Some(pos)
-        } else {
-          middle.index_of(item).map(|pos| pos + left.len())
-        }
-      }
-      Branch3 { left, middle, right, .. } => {
-        if let Some(pos) = left.index_of(item) {
-          Some(pos)
-        } else if let Some(pos) = middle.index_of(item) {
-          Some(pos + left.len())
-        } else {
-          right.index_of(item).map(|pos| pos + left.len() + middle.len())
-        }
-      }
+      Tree(t) => t.index_of(item),
     }
   }
 
   /// recursively check structure
   pub fn is_shape_same(&self, ys: &Self) -> bool {
-    if self.is_empty() {
-      return ys.is_empty();
-    }
-
-    if ys.is_empty() {
-      return false;
-    }
-
-    if self.len() != ys.len() {
-      return false;
-    }
-
     match (self, ys) {
-      (Leaf(value), Leaf(v2)) => value == v2,
-      (
-        Branch2 { left, middle, .. },
-        Branch2 {
-          left: left2,
-          middle: middle2,
-          ..
-        },
-      ) => left.is_shape_same(left2) && middle.is_shape_same(middle2),
-      (
-        Branch3 { left, middle, right, .. },
-        Branch3 {
-          left: left2,
-          middle: middle2,
-          right: right2,
-          ..
-        },
-      ) => left.is_shape_same(left2) && middle.is_shape_same(middle2) && right.is_shape_same(right2),
-
-      (_, _) => false,
+      (Empty, Empty) => true,
+      (Empty, _) => false,
+      (_, Empty) => false,
+      (Tree(x), Tree(y)) => x.is_shape_same(y),
     }
-  }
-
-  /// internal usages for rebuilding tree
-  fn to_leaves(&self) -> Vec<TernaryTreeList<T>> {
-    let mut acc: Vec<TernaryTreeList<T>> = Vec::with_capacity(self.len());
-    let counter: RefCell<usize> = RefCell::new(0);
-    write_leaves(self, &mut acc, &counter);
-    assert_eq!(acc.len(), self.len());
-    acc
   }
 
   pub fn ref_get(&self, idx: usize) -> Option<&T> {
-    // println!("get: {} {}", self.format_inline(), idx);
-    // if idx >= self.len() {
-    //   println!("get from out of bound: {} {}", idx, self.len());
-    //   return None;
-    // }
     match self {
-      Branch3 { left, middle, right, .. } => {
-        let base = left.len();
-        if idx < base {
-          left.ref_get(idx)
-        } else if idx < base + middle.len() {
-          middle.ref_get(idx - base)
-        } else {
-          right.ref_get(idx - left.len() - middle.len())
-        }
-      }
-      Branch2 { left, middle, .. } => {
-        if idx < left.len() {
-          left.ref_get(idx)
-        } else {
-          middle.ref_get(idx - left.len())
-        }
-      }
-      Leaf(value) => Some(value),
-      Empty => unreachable!("out of bound, trying to get from empty"),
+      Empty => None,
+      Tree(t) => t.ref_get(idx),
     }
   }
 
   /// get via go down the branch with a mutable loop
   pub fn loop_get(&self, original_idx: usize) -> Option<T> {
-    let mut tree_parent = self.to_owned();
-    let mut idx = original_idx;
-    while tree_parent != Empty {
-      match tree_parent {
-        Empty => {
-          println!("[warning] trying to get {} from empty", idx);
-          return None;
-        }
-        Leaf(value) => {
-          if idx == 0 {
-            return Some((*value).to_owned());
-          } else {
-            println!("[warning] Cannot get from leaf with index {}", idx);
-            return None;
-          }
-        }
-        Branch2 { left, middle, size, .. } => {
-          if idx > size - 1 {
-            println!("[warning] Index too large at {} from {}", idx, size);
-            return None;
-          }
-
-          if left.len() + middle.len() != size {
-            unreachable!("tree.size does not match sum case branch sizes");
-          }
-
-          if idx < left.len() {
-            tree_parent = (*left).to_owned();
-          } else {
-            tree_parent = (*middle).to_owned();
-            idx -= left.len();
-          }
-        }
-        Branch3 {
-          left, middle, right, size, ..
-        } => {
-          if idx > size - 1 {
-            println!("[warning] Index too large at {} from {}", idx, size);
-            return None;
-          }
-
-          if left.len() + middle.len() + right.len() != size {
-            unreachable!("tree.size does not match sum case branch sizes");
-          }
-
-          if idx < left.len() {
-            tree_parent = (*left).to_owned();
-          } else if idx < left.len() + middle.len() {
-            tree_parent = (*middle).to_owned();
-            idx -= left.len();
-          } else {
-            tree_parent = (*right).to_owned();
-            idx -= left.len() + middle.len();
-          }
-        }
-      }
+    match self {
+      Empty => None,
+      Tree(t) => t.loop_get(original_idx),
     }
-
-    unreachable!("Failed to get ${idx}")
   }
 
   pub fn first(&self) -> Option<&T> {
@@ -379,202 +130,15 @@ where
     }
   }
   pub fn assoc(&self, idx: usize, item: T) -> Result<Self, String> {
-    if idx > self.len() - 1 {
-      return Err(format!("Index too large {} for {}", idx, self.format_inline()));
-    }
-
     match self {
-      Empty => return Err(format!("Cannot assoc into empty, {}", idx)),
-      Leaf { .. } => {
-        if idx == 0 {
-          Ok(Leaf(Arc::new(item)))
-        } else {
-          Err(format!("Cannot assoc leaf into index {}", idx))
-        }
-      }
-      Branch2 { left, middle, size, .. } => {
-        if left.len() + middle.len() != *size {
-          return Err(format!(
-            "tree size {} does not match sum case branch sizes, {}",
-            size,
-            self.format_inline()
-          ));
-        }
-
-        if idx < left.len() {
-          let changed_branch = left.assoc(idx, item)?;
-          Ok(Branch2 {
-            size: size.to_owned(),
-            depth: decide_parent_depth_2(&changed_branch, middle),
-            left: Arc::new(changed_branch),
-            middle: middle.to_owned(),
-          })
-        } else {
-          let changed_branch = middle.assoc(idx - left.len(), item)?;
-          Ok(Branch2 {
-            size: size.to_owned(),
-            depth: decide_parent_depth_2(left, &changed_branch),
-            left: left.to_owned(),
-            middle: Arc::new(changed_branch),
-          })
-        }
-      }
-      Branch3 {
-        left, middle, right, size, ..
-      } => {
-        if left.len() + middle.len() + right.len() != *size {
-          return Err(format!(
-            "tree size {} does not match sum case branch sizes, {}",
-            size,
-            self.format_inline()
-          ));
-        }
-
-        if idx < left.len() {
-          let changed_branch = left.assoc(idx, item)?;
-          Ok(Branch3 {
-            size: size.to_owned(),
-            depth: decide_parent_depth_3(&changed_branch, middle, right),
-            left: Arc::new(changed_branch),
-            middle: middle.to_owned(),
-            right: right.to_owned(),
-          })
-        } else if idx < left.len() + middle.len() {
-          let changed_branch = middle.assoc(idx - left.len(), item)?;
-          Ok(Branch3 {
-            size: size.to_owned(),
-            depth: decide_parent_depth_3(left, &changed_branch, right),
-            left: left.to_owned(),
-            middle: Arc::new(changed_branch),
-            right: right.to_owned(),
-          })
-        } else {
-          let changed_branch = right.assoc(idx - left.len() - middle.len(), item)?;
-          Ok(Branch3 {
-            size: size.to_owned(),
-            depth: decide_parent_depth_3(left, middle, &changed_branch),
-            left: left.to_owned(),
-            middle: middle.to_owned(),
-            right: Arc::new(changed_branch.to_owned()),
-          })
-        }
-      }
+      Empty => Err(String::from("empty")),
+      Tree(t) => Ok(TernaryTreeList::Tree(t.assoc(idx, item)?)),
     }
   }
   pub fn dissoc(&self, idx: usize) -> Result<Self, String> {
-    if self.is_empty() {
-      return Err(String::from("Cannot remove from empty list"));
-    }
-
-    if idx > self.len() - 1 {
-      return Err(format!("Index too large {} for {}", idx, self.len()));
-    } else if self.len() == 1 {
-      // idx already == 0
-      return Ok(Empty);
-    }
-
     match self {
-      Empty => unreachable!("dissoc out of bound"),
-      Leaf { .. } => unreachable!("dissoc should be handled at branches"),
-      Branch2 { left, middle, size, .. } => {
-        if left.len() + middle.len() != *size {
-          return Err(format!(
-            "tree {} does not match sum from branch sizes {}",
-            self.format_inline(),
-            self.len()
-          ));
-        }
-
-        if idx < left.len() {
-          if left.len() == 1 {
-            Ok((**middle).to_owned())
-          } else {
-            let changed_branch = left.dissoc(idx)?;
-            Ok(Branch2 {
-              size: *size - 1,
-              depth: decide_parent_depth_2(&changed_branch, middle),
-              left: Arc::new(changed_branch),
-              middle: middle.to_owned(),
-            })
-          }
-        } else if left.len() == 1 {
-          Ok((**left).to_owned())
-        } else {
-          let changed_branch = middle.dissoc(idx - left.len())?;
-          Ok(Branch2 {
-            size: *size - 1,
-            depth: decide_parent_depth_2(left, &changed_branch),
-            left: left.to_owned(),
-            middle: Arc::new(changed_branch),
-          })
-        }
-      }
-
-      Branch3 {
-        left, middle, right, size, ..
-      } => {
-        if left.len() + middle.len() + right.len() != *size {
-          return Err(format!(
-            "tree {} does not match sum from branch sizes {}",
-            self.format_inline(),
-            self.len()
-          ));
-        }
-
-        if idx < left.len() {
-          if left.len() == 1 {
-            Ok(Branch2 {
-              size: *size - 1,
-              depth: decide_parent_depth_2(middle, right),
-              left: middle.to_owned(),
-              middle: right.to_owned(),
-            })
-          } else {
-            let changed_branch = left.dissoc(idx)?;
-            Ok(Branch3 {
-              size: *size - 1,
-              depth: decide_parent_depth_3(&changed_branch, middle, right),
-              left: Arc::new(changed_branch),
-              middle: middle.to_owned(),
-              right: right.to_owned(),
-            })
-          }
-        } else if idx < left.len() + middle.len() {
-          if middle.len() == 1 {
-            Ok(Branch2 {
-              size: *size - 1,
-              depth: decide_parent_depth_2(left, right),
-              left: left.to_owned(),
-              middle: right.to_owned(),
-            })
-          } else {
-            let changed_branch = middle.dissoc(idx - left.len())?;
-            Ok(Branch3 {
-              size: *size - 1,
-              depth: decide_parent_depth_3(left, &changed_branch, right),
-              left: left.to_owned(),
-              middle: Arc::new(changed_branch),
-              right: right.to_owned(),
-            })
-          }
-        } else if right.len() == 1 {
-          Ok(Branch2 {
-            size: *size - 1,
-            depth: decide_parent_depth_2(left, middle),
-            left: left.to_owned(),
-            middle: middle.to_owned(),
-          })
-        } else {
-          let changed_branch = right.dissoc(idx - left.len() - middle.len())?;
-          Ok(Branch3 {
-            size: *size - 1,
-            depth: decide_parent_depth_3(left, middle, &changed_branch),
-            left: left.to_owned(),
-            middle: middle.to_owned(),
-            right: Arc::new(changed_branch.to_owned()),
-          })
-        }
-      }
+      Empty => Err(String::from("calling dissoc from empty")),
+      Tree(t) => Ok(TernaryTreeList::Tree(t.dissoc(idx)?)),
     }
   }
   pub fn rest(&self) -> Result<Self, String> {
@@ -596,288 +160,13 @@ where
     match self {
       Empty => {
         if idx == 0 {
-          Ok(Leaf(Arc::new(item)))
+          Ok(TernaryTreeList::Tree(TernaryTree::Leaf(Arc::new(item))))
         } else {
-          Err(format!(
-            "Empty node is not a correct position for inserting {} for {}",
-            idx,
-            self.len()
-          ))
-        }
-      }
-      Leaf { .. } => {
-        if after {
-          Ok(Branch2 {
-            depth: 1,
-            size: 2,
-            left: Arc::new(self.to_owned()),
-            middle: Arc::new(Leaf(Arc::new(item))),
-          })
-        } else {
-          Ok(Branch2 {
-            depth: 1,
-            size: 2,
-            left: Arc::new(Leaf(Arc::new(item))),
-            middle: Arc::new(self.to_owned()),
-          })
+          Err(String::from("inserting into empty, but index is not 0"))
         }
       }
 
-      Branch2 {
-        left, middle, size, depth, ..
-      } => {
-        if self.len() == 1 {
-          if after {
-            // in compact mode, values placed at left
-            return Ok(Branch2 {
-              size: 2,
-              depth: 1,
-              left: left.to_owned(),
-              middle: Arc::new(Leaf(Arc::new(item))),
-            });
-          } else {
-            return Ok(Branch2 {
-              size: 2,
-              depth: 1,
-              left: Arc::new(Leaf(Arc::new(item))),
-              middle: left.to_owned(),
-            });
-          }
-        }
-
-        if self.len() == 2 {
-          if after {
-            if idx == 0 {
-              return Ok(Branch3 {
-                size: 3,
-                depth: 1,
-                left: left.to_owned(),
-                middle: Arc::new(Leaf(Arc::new(item))),
-                right: middle.to_owned(),
-              });
-            }
-            if idx == 1 {
-              return Ok(Branch3 {
-                size: 3,
-                depth: 1,
-                left: left.to_owned(),
-                middle: middle.to_owned(),
-                right: Arc::new(Leaf(Arc::new(item))),
-              });
-            } else {
-              return Err(String::from("cannot insert after position 2 since only 2 elements here"));
-            }
-          } else if idx == 0 {
-            return Ok(Branch3 {
-              size: 3,
-              depth: 1,
-              left: Arc::new(Leaf(Arc::new(item))),
-              middle: left.to_owned(),
-              right: middle.to_owned(),
-            });
-          } else if idx == 1 {
-            return Ok(Branch3 {
-              size: 3,
-              depth: 1,
-              left: left.to_owned(),
-              middle: Arc::new(Leaf(Arc::new(item))),
-              right: middle.to_owned(),
-            });
-          } else {
-            return Err(String::from("cannot insert before position 2 since only 2 elements here"));
-          }
-        }
-
-        if left.len() + middle.len() != *size {
-          return Err(String::from("tree.size does not match sum case branch sizes"));
-        }
-
-        // echo "picking: ", idx, " ", left.len(), " ", middle.len(), " ", right.len()
-
-        if idx == 0 && !after {
-          return Ok(Branch3 {
-            size: *size + 1,
-            depth: *depth,
-            left: Arc::new(Leaf(Arc::new(item))),
-            middle: left.to_owned(),
-            right: middle.to_owned(),
-          });
-        }
-
-        if idx == *size - 1 && after {
-          return Ok(Branch3 {
-            size: *size + 1,
-            depth: *depth,
-            left: left.to_owned(),
-            middle: middle.to_owned(),
-            right: Arc::new(Leaf(Arc::new(item))),
-          });
-        }
-
-        if idx < left.len() {
-          let changed_branch = left.insert(idx, item, after)?;
-          Ok(Branch2 {
-            size: *size + 1,
-            depth: decide_parent_depth_2(&changed_branch, middle),
-            left: Arc::new(changed_branch),
-            middle: middle.to_owned(),
-          })
-        } else {
-          let changed_branch = middle.insert(idx - left.len(), item, after)?;
-
-          Ok(Branch2 {
-            size: *size + 1,
-            depth: decide_parent_depth_2(left, &changed_branch.to_owned()),
-            left: left.to_owned(),
-            middle: Arc::new(changed_branch),
-          })
-        }
-      }
-      Branch3 {
-        left,
-        middle,
-        right,
-        size,
-        depth,
-        ..
-      } => {
-        if self.len() == 1 {
-          if after {
-            // in compact mode, values placed at left
-            return Ok(Branch2 {
-              size: 2,
-              depth: 1,
-              left: left.to_owned(),
-              middle: Arc::new(Leaf(Arc::new(item))),
-            });
-          } else {
-            return Ok(Branch2 {
-              size: 2,
-              depth: 1,
-              left: Arc::new(Leaf(Arc::new(item))),
-              middle: left.to_owned(),
-            });
-          }
-        }
-
-        if self.len() == 2 {
-          if after {
-            if idx == 0 {
-              return Ok(Branch3 {
-                size: 3,
-                depth: 1,
-                left: left.to_owned(),
-                middle: Arc::new(Leaf(Arc::new(item))),
-                right: middle.to_owned(),
-              });
-            }
-            if idx == 1 {
-              return Ok(Branch3 {
-                size: 3,
-                depth: 1,
-                left: left.to_owned(),
-                middle: middle.to_owned(),
-                right: Arc::new(Leaf(Arc::new(item))),
-              });
-            } else {
-              return Err(String::from("cannot insert after position 2 since only 2 elements here"));
-            }
-          } else if idx == 0 {
-            return Ok(Branch3 {
-              size: 3,
-              depth: 1,
-              left: Arc::new(Leaf(Arc::new(item))),
-              middle: left.to_owned(),
-              right: middle.to_owned(),
-            });
-          } else if idx == 1 {
-            return Ok(Branch3 {
-              size: 3,
-              depth: 1,
-              left: left.to_owned(),
-              middle: Arc::new(Leaf(Arc::new(item))),
-              right: middle.to_owned(),
-            });
-          } else {
-            return Err(String::from("cannot insert before position 2 since only 2 elements here"));
-          }
-        }
-
-        if left.len() + middle.len() + right.len() != *size {
-          return Err(String::from("tree.size does not match sum case branch sizes"));
-        }
-
-        // echo "picking: ", idx, " ", left.len(), " ", middle.len(), " ", right.len()
-
-        if idx == 0 && !after && left.len() >= middle.len() && left.len() >= right.len() {
-          return Ok(Branch2 {
-            size: *size + 1,
-            depth: depth + 1,
-            left: Arc::new(Leaf(Arc::new(item))),
-            middle: Arc::new(self.to_owned()),
-          });
-        }
-
-        if idx == *size - 1 && after && right.len() >= middle.len() && right.len() >= left.len() {
-          return Ok(Branch2 {
-            size: *size + 1,
-            depth: depth + 1,
-            left: Arc::new(self.to_owned()),
-            middle: Arc::new(Leaf(Arc::new(item))),
-          });
-        }
-
-        if after && idx == *size - 1 && right.len() == 0 && middle.len() >= left.len() {
-          return Ok(Branch3 {
-            size: *size + 1,
-            depth: depth.to_owned(),
-            left: left.to_owned(),
-            middle: middle.to_owned(),
-            right: Arc::new(Leaf(Arc::new(item))),
-          });
-        }
-
-        if !after && idx == 0 && right.len() == 0 && middle.len() >= right.len() {
-          return Ok(Branch3 {
-            size: *size + 1,
-            depth: depth.to_owned(),
-            left: Arc::new(Leaf(Arc::new(item))),
-            middle: left.to_owned(),
-            right: middle.to_owned(),
-          });
-        }
-
-        if idx < left.len() {
-          let changed_branch = left.insert(idx, item, after)?;
-          Ok(Branch3 {
-            size: *size + 1,
-            depth: decide_parent_depth_3(&changed_branch, middle, right),
-            left: Arc::new(changed_branch.to_owned()),
-            middle: middle.to_owned(),
-            right: right.to_owned(),
-          })
-        } else if idx < left.len() + middle.len() {
-          let changed_branch = middle.insert(idx - left.len(), item, after)?;
-
-          Ok(Branch3 {
-            size: *size + 1,
-            depth: decide_parent_depth_3(left, &changed_branch.to_owned(), right),
-            left: left.to_owned(),
-            middle: Arc::new(changed_branch.to_owned()),
-            right: right.to_owned(),
-          })
-        } else {
-          let changed_branch = right.insert(idx - left.len() - middle.len(), item, after)?;
-
-          Ok(Branch3 {
-            size: *size + 1,
-            depth: decide_parent_depth_3(left, middle, &changed_branch),
-            left: left.to_owned(),
-            middle: middle.to_owned(),
-            right: Arc::new(changed_branch.to_owned()),
-          })
-        }
-      }
+      Tree(t) => Ok(TernaryTreeList::Tree(t.insert(idx, item, after)?)),
     }
   }
   pub fn assoc_before(&self, idx: usize, item: T) -> Result<Self, String> {
@@ -888,29 +177,16 @@ where
   }
   // this function mutates original tree to make it more balanced
   pub fn force_inplace_balancing(&mut self) -> Result<(), String> {
-    let ys = self.to_leaves();
-    *self = Self::rebuild_list(ys.len(), 0, &ys);
-    Ok(())
+    match self {
+      Empty => Ok(()),
+      Tree(t) => t.force_inplace_balancing(),
+    }
   }
-  // TODO, need better strategy for detecting
+
   pub fn maybe_reblance(&mut self) -> Result<(), String> {
     match self {
       Empty => Ok(()),
-      Leaf(..) => Ok(()),
-      Branch2 { .. } => Ok(()),
-      Branch3 { size, .. } => {
-        // guessed number
-        if *size < 81 {
-          Ok(())
-        } else {
-          let current_depth = self.get_depth();
-          if current_depth > 20 && rough_int_pow(3, current_depth - 20) > self.len() {
-            self.force_inplace_balancing()
-          } else {
-            Ok(())
-          }
-        }
-      }
+      Tree(t) => t.maybe_reblance(),
     }
   }
 
@@ -918,453 +194,59 @@ where
     self.prepend(item, false)
   }
   pub fn prepend(&self, item: T, disable_balancing: bool) -> Self {
-    if self.is_empty() {
-      return Leaf(Arc::new(item));
+    match self {
+      Empty => TernaryTreeList::Tree(TernaryTree::Leaf(Arc::new(item))),
+      Tree(t) => TernaryTreeList::Tree(t.prepend(item, disable_balancing)),
     }
-
-    let mut result = match self.insert(0, item, false) {
-      Ok(v) => v,
-      Err(e) => unreachable!(e),
-    };
-
-    if !disable_balancing {
-      if let Err(msg) = result.maybe_reblance() {
-        println!("[warning] {}", msg)
-      }
-    }
-
-    result
   }
   pub fn push(&self, item: T) -> Self {
     self.append(item, false)
   }
   pub fn append(&self, item: T, disable_balancing: bool) -> Self {
-    if self.is_empty() {
-      return Leaf(Arc::new(item));
-    }
-    let mut result = match self.insert(self.len() - 1, item, true) {
-      Ok(v) => v,
-      Err(e) => unreachable!(e),
-    };
-
-    if !disable_balancing {
-      if let Err(msg) = result.maybe_reblance() {
-        println!("[warning] {}", msg)
-      }
-    }
-    result
-  }
-
-  fn push_right_iter(&self, item: Self, mark: FingerMark) -> Self {
-    // println!("    iter: {} {:?}", self.format_inline(), mark);
-    match mark {
-      FingerMark::Main(n) => match self {
-        Empty => item,
-        Leaf(a) => Branch2 {
-          size: 1 + item.len(),
-          depth: item.get_depth() + 1,
-          left: Arc::new(Leaf(a.to_owned())),
-          middle: Arc::new(item),
-        },
-        Branch2 { size, left, middle, .. } => {
-          if middle.len() + item.len() > left.len() || middle.len() >= triple_size(n) {
-            Branch3 {
-              size: size + item.len(),
-              depth: decide_parent_depth_3(left, middle, &item),
-              left: left.to_owned(),
-              middle: middle.to_owned(),
-              right: Arc::new(item),
-            }
-          } else {
-            let item_size = item.len();
-            let changed_branch = middle.push_right_iter(item, FingerMark::Side(n - 1));
-
-            Branch2 {
-              size: size + item_size,
-              depth: decide_parent_depth_2(left, &changed_branch),
-              left: left.to_owned(),
-              middle: Arc::new(changed_branch),
-            }
-          }
-        }
-        Branch3 {
-          size, left, middle, right, ..
-        } => {
-          if right.len() + item.len() > middle.len() || middle.len() >= triple_size(n) {
-            Branch2 {
-              size: size + item.len(),
-              depth: decide_parent_depth_2(self, &item),
-              left: Arc::new(self.to_owned()),
-              middle: Arc::new(item),
-            }
-          } else {
-            let changed_branch = right.push_right_iter(item, FingerMark::Side(n - 1));
-            Branch3 {
-              size: size + 1,
-              depth: decide_parent_depth_3(left, middle, &changed_branch),
-              left: left.to_owned(),
-              middle: middle.to_owned(),
-              right: Arc::new(changed_branch),
-            }
-          }
-        }
-      },
-      FingerMark::Side(n) => match self {
-        Empty => item,
-        Leaf(a) => Branch2 {
-          size: 1 + item.len(),
-          depth: item.get_depth() + 1,
-          left: Arc::new(Leaf(a.to_owned())),
-          middle: Arc::new(item),
-        },
-        Branch2 { size, left, middle, .. } => {
-          if middle.len() + item.len() > left.len() {
-            Branch3 {
-              size: size + item.len(),
-              depth: decide_parent_depth_3(left, middle, &item),
-              left: left.to_owned(),
-              middle: middle.to_owned(),
-              right: Arc::new(item),
-            }
-          } else {
-            let changed_branch = middle.push_right_iter(item.to_owned(), FingerMark::Side(n - 1));
-            Branch2 {
-              size: size + item.len(),
-              depth: decide_parent_depth_3(left, middle, &changed_branch),
-              left: left.to_owned(),
-              middle: Arc::new(changed_branch),
-            }
-          }
-        }
-        Branch3 {
-          size, left, middle, right, ..
-        } => {
-          if right.len() + item.len() > middle.len() {
-            Branch2 {
-              size: size + item.len(),
-              depth: decide_parent_depth_2(self, &item),
-              left: Arc::new(self.to_owned()),
-              middle: Arc::new(item),
-            }
-          } else {
-            let changed_branch = right.push_right_iter(item.to_owned(), FingerMark::Side(n - 1));
-            Branch3 {
-              size: size + item.len(),
-              depth: decide_parent_depth_3(left, middle, &changed_branch),
-              left: left.to_owned(),
-              middle: middle.to_owned(),
-              right: Arc::new(changed_branch),
-            }
-          }
-        }
-      },
+    match self {
+      Empty => TernaryTreeList::Tree(TernaryTree::Leaf(Arc::new(item))),
+      Tree(t) => TernaryTreeList::Tree(t.append(item, disable_balancing)),
     }
   }
-
   pub fn push_right(&self, item: T) -> Self {
-    // start with 2 so its left child branch has capability of only 3^1
-    self.push_right_iter(Leaf(Arc::new(item)), FingerMark::Main(2))
+    match self {
+      Empty => TernaryTreeList::Tree(TernaryTree::Leaf(Arc::new(item))),
+      Tree(t) => TernaryTreeList::Tree(t.push_right(item)),
+    }
   }
 
   pub fn drop_left(&self) -> Self {
     match self {
-      Empty => unreachable!("cannot drop from empty"),
-      Leaf(_) => {
-        unreachable!("not expected empty node inside tree")
-      }
-      Branch2 { size, left, middle, .. } => {
-        if left.len() == 1 {
-          (**middle).to_owned()
-        } else {
-          let changed_branch = left.drop_left();
-          match changed_branch {
-            Empty => unreachable!("does not expect empty inside tree"),
-            Branch2 {
-              left: b_left,
-              middle: b_middle,
-              ..
-            } => Branch3 {
-              size: size - 1,
-              depth: decide_parent_depth_3(&b_left, &b_middle, middle),
-              left: b_left.to_owned(),
-              middle: b_middle.to_owned(),
-              right: middle.to_owned(),
-            },
-            Branch3 {
-              left: b_left,
-              middle: b_middle,
-              right: b_right,
-              ..
-            } => {
-              let internal_branch = Branch2 {
-                size: b_middle.len() + b_right.len(),
-                depth: decide_parent_depth_2(&b_middle, &b_right),
-                left: b_middle,
-                middle: b_right,
-              };
-              Branch3 {
-                size: size - 1,
-                depth: decide_parent_depth_3(&b_left, &internal_branch, middle),
-                left: b_left.to_owned(),
-                middle: Arc::new(internal_branch),
-                right: middle.to_owned(),
-              }
-            }
-            _ => Branch2 {
-              size: size - 1,
-              depth: decide_parent_depth_2(&changed_branch, middle),
-              left: Arc::new(changed_branch),
-              middle: middle.to_owned(),
-            },
-          }
-        }
-      }
-      Branch3 {
-        size, left, middle, right, ..
-      } => {
-        if left.len() == 1 {
-          match &**middle {
-            Empty => unreachable!("unexpected empty inside tree"),
-            Branch2 {
-              left: b_left,
-              middle: b_middle,
-              ..
-            } => Branch3 {
-              size: size - 1,
-              depth: decide_parent_depth_3(b_left, b_middle, right),
-              left: b_left.to_owned(),
-              middle: b_middle.to_owned(),
-              right: right.to_owned(),
-            },
-            Branch3 {
-              left: b_left,
-              middle: b_middle,
-              right: b_right,
-              ..
-            } => {
-              let internal_branch = Branch2 {
-                size: b_middle.len() + b_right.len(),
-                depth: decide_parent_depth_2(b_middle, b_right),
-                left: b_middle.to_owned(),
-                middle: b_right.to_owned(),
-              };
-              Branch3 {
-                size: size - 1,
-                depth: decide_parent_depth_3(b_left, &internal_branch, right),
-                left: b_left.to_owned(),
-                middle: Arc::new(internal_branch),
-                right: right.to_owned(),
-              }
-            }
-            _ => Branch2 {
-              size: size - 1,
-              depth: decide_parent_depth_2(middle, right),
-              left: middle.to_owned(),
-              middle: right.to_owned(),
-            },
-          }
-        } else {
-          let changed_branch = left.drop_left();
-          Branch3 {
-            size: size - 1,
-            depth: decide_parent_depth_3(&changed_branch, middle, right),
-            left: Arc::new(changed_branch),
-            middle: middle.to_owned(),
-            right: right.to_owned(),
-          }
-        }
-      }
+      Empty => TernaryTreeList::Empty,
+      Tree(t) => TernaryTreeList::Tree(t.drop_left()),
     }
   }
 
   pub fn concat(raw: &[TernaryTreeList<T>]) -> Self {
-    let mut xs_groups: Vec<TernaryTreeList<T>> = Vec::with_capacity(raw.len());
+    let mut trees: Vec<TernaryTree<T>> = vec![];
     for x in raw {
-      if !x.is_empty() {
-        xs_groups.push(x.to_owned());
+      match x {
+        Empty => (),
+        Tree(t) => trees.push(t.clone()),
       }
     }
-    match xs_groups.len() {
-      0 => TernaryTreeList::Empty,
-      1 => xs_groups[0].to_owned(),
-      2 => {
-        let left = xs_groups[0].to_owned();
-        let middle = xs_groups[1].to_owned();
-        TernaryTreeList::Branch2 {
-          size: left.len() + middle.len(),
-          depth: decide_parent_depth_2(&left, &middle),
-          left: Arc::new(left),
-          middle: Arc::new(middle),
-        }
-      }
-      3 => {
-        let left = xs_groups[0].to_owned();
-        let middle = xs_groups[1].to_owned();
-        let right = xs_groups[2].to_owned();
-        TernaryTreeList::Branch3 {
-          size: left.len() + middle.len() + right.len(),
-          depth: decide_parent_depth_3(&left, &middle, &right),
-          left: Arc::new(left),
-          middle: Arc::new(middle),
-          right: Arc::new(right),
-        }
-      }
-      _ => {
-        let mut ys: Vec<TernaryTreeList<T>> = vec![];
-        for x in xs_groups {
-          if !x.is_empty() {
-            ys.push(x.to_owned())
-          }
-        }
-        let mut result = Self::rebuild_list(ys.len(), 0, &ys);
-        if let Err(msg) = result.maybe_reblance() {
-          println!("[warning] {}", msg)
-        }
-        result
-      }
+    if trees.is_empty() {
+      TernaryTreeList::Empty
+    } else {
+      TernaryTreeList::Tree(TernaryTree::concat(&trees))
     }
   }
   pub fn check_structure(&self) -> Result<(), String> {
-    if self.is_empty() {
-      Ok(())
-    } else {
-      match self {
-        Empty => Ok(()),
-        Leaf { .. } => Ok(()),
-        Branch2 { left, middle, size, depth } => {
-          if !self.is_empty() && *size == 0 {
-            return Err(String::from("branch but has size"));
-          }
-
-          if *size != left.len() + middle.len() {
-            return Err(format!("Bad size at branch {}", self.format_inline()));
-          }
-
-          if *depth != decide_parent_depth_2(left, middle) {
-            return Err(format!("Bad depth at branch {}", self.format_inline()));
-          }
-
-          left.check_structure()?;
-          middle.check_structure()?;
-
-          Ok(())
-        }
-        Branch3 {
-          left,
-          middle,
-          right,
-          size,
-          depth,
-        } => {
-          if !self.is_empty() && *size == 0 {
-            return Err(String::from("branch but has size"));
-          }
-
-          if *size != left.len() + middle.len() + right.len() {
-            return Err(format!("Bad size at branch {}", self.format_inline()));
-          }
-
-          if *depth != decide_parent_depth_3(left, middle, right) {
-            return Err(format!("Bad depth at branch {}", self.format_inline()));
-          }
-
-          left.check_structure()?;
-          middle.check_structure()?;
-          right.check_structure()?;
-
-          Ok(())
-        }
-      }
+    match self {
+      Empty => Ok(()),
+      Tree(t) => t.check_structure(),
     }
   }
   // excludes value at end_idx, kept aligned with JS & Clojure
   pub fn slice(&self, start_idx: usize, end_idx: usize) -> Result<Self, String> {
-    // echo "slice {tree.formatListInline}: {start_idx}..{end_idx}"
-    if end_idx > self.len() {
-      return Err(format!("Slice range too large {} for {}", end_idx, self.format_inline()));
-    }
-    if start_idx > end_idx {
-      return Err(format!("Invalid slice range {}..{} for {}", start_idx, end_idx, self));
-    }
-    if start_idx == end_idx {
-      return Ok(Empty);
-    }
-
     match self {
-      Empty => return Err(format!("slicing {}..{} from empty", start_idx, end_idx)),
-      Leaf { .. } => {
-        if start_idx == 0 && end_idx == 1 {
-          Ok(self.to_owned())
-        } else {
-          Err(format!("Invalid slice range for a leaf: {} {}", start_idx, end_idx))
-        }
-      }
-
-      Branch2 { left, middle, .. } => {
-        if start_idx == 0 && end_idx == self.len() {
-          Ok(self.to_owned())
-        } else if start_idx >= left.len() {
-          // echo "sizes: {left.len()} {middle.len()} {right.len()}"
-          middle.slice(start_idx - left.len(), end_idx - left.len())
-        } else if end_idx <= left.len() {
-          left.slice(start_idx, end_idx)
-        } else {
-          let left_cut = left.slice(start_idx, left.len())?;
-          let middle_cut = middle.slice(0, end_idx - left.len())?;
-
-          Ok(TernaryTreeList::Branch2 {
-            size: left_cut.len() + middle_cut.len(),
-            depth: decide_parent_depth_2(&left_cut, &middle_cut),
-            left: Arc::new(left_cut),
-            middle: Arc::new(middle_cut),
-          })
-        }
-      }
-      Branch3 { left, right, middle, .. } => {
-        let base1 = left.len();
-        let base2 = base1 + middle.len();
-        if start_idx == 0 && end_idx == self.len() {
-          Ok(self.to_owned())
-        } else if start_idx >= base2 {
-          right.slice(start_idx - base2, end_idx - base2)
-        } else if start_idx >= base1 {
-          if end_idx <= base1 + middle.len() {
-            middle.slice(start_idx - base1, end_idx - base1)
-          } else {
-            let middle_cut = middle.slice(start_idx - base1, middle.len())?;
-            let right_cut = right.slice(0, end_idx - base2)?;
-
-            Ok(TernaryTreeList::Branch2 {
-              size: middle_cut.len() + right_cut.len(),
-              depth: decide_parent_depth_2(&middle_cut, &right_cut),
-              left: Arc::new(middle_cut),
-              middle: Arc::new(right_cut),
-            })
-          }
-        } else if end_idx <= base1 {
-          left.slice(start_idx, end_idx)
-        } else if end_idx <= base2 {
-          let left_cut = left.slice(start_idx, base1)?;
-          let middle_cut = middle.slice(0, end_idx - base1)?;
-
-          Ok(TernaryTreeList::Branch2 {
-            size: left_cut.len() + middle_cut.len(),
-            depth: decide_parent_depth_2(&left_cut, &middle_cut),
-            left: Arc::new(left_cut),
-            middle: Arc::new(middle_cut),
-          })
-        } else {
-          let left_cut = left.slice(start_idx, base1)?;
-          let right_cut = right.slice(0, end_idx - base2)?;
-          Ok(TernaryTreeList::Branch3 {
-            size: left_cut.len() + middle.len() + right_cut.len(),
-            depth: decide_parent_depth_3(&left_cut, middle, &right_cut),
-            left: Arc::new(left_cut),
-            middle: middle.clone(),
-            right: Arc::new(right_cut),
-          })
-        }
-      }
+      Empty => Err(String::from("empty")),
+      Tree(t) => Ok(TernaryTreeList::Tree(t.slice(start_idx, end_idx)?)),
     }
   }
 
@@ -1376,92 +258,28 @@ where
   }
 
   pub fn reverse(&self) -> Self {
-    if self.is_empty() {
-      return Empty;
-    }
-
     match self {
-      Empty => Empty,
-      Leaf { .. } => self.to_owned(),
-      Branch2 { left, middle, size, depth } => Branch2 {
-        size: *size,
-        depth: *depth,
-        left: Arc::new(middle.reverse()),
-        middle: Arc::new(left.reverse()),
-      },
-      Branch3 {
-        left,
-        middle,
-        right,
-        size,
-        depth,
-      } => Branch3 {
-        size: *size,
-        depth: *depth,
-        left: Arc::new(right.reverse()),
-        middle: Arc::new(middle.reverse()),
-        right: Arc::new(left.reverse()),
-      },
+      Empty => TernaryTreeList::Empty,
+      Tree(t) => TernaryTreeList::Tree(t.reverse()),
     }
   }
   pub fn map<V>(&self, f: Arc<dyn Fn(&T) -> V>) -> TernaryTreeList<V> {
     match self {
-      Empty => Empty,
-      Leaf(value) => Leaf(Arc::new(f(value))),
-      Branch2 { left, middle, size, depth } => Branch2 {
-        size: *size,
-        depth: *depth,
-        left: Arc::new(left.map(f.clone())),
-        middle: Arc::new(middle.map(f.clone())),
-      },
-      Branch3 {
-        left,
-        middle,
-        right,
-        size,
-        depth,
-      } => Branch3 {
-        size: *size,
-        depth: *depth,
-        left: Arc::new(left.map(f.clone())),
-        middle: Arc::new(middle.map(f.clone())),
-        right: Arc::new(right.map(f.clone())),
-      },
+      Empty => TernaryTreeList::Empty,
+      Tree(t) => TernaryTreeList::Tree(t.map(f)),
     }
   }
 
   pub fn to_vec(&self) -> Vec<T> {
-    let mut xs = vec![];
-
-    // TODO
-    for item in self {
-      xs.push(item.to_owned());
+    match self {
+      Empty => Vec::new(),
+      Tree(t) => t.to_vec(),
     }
-
-    xs
   }
 
-  pub fn iter(&self) -> TernaryTreeRefIntoIterator<T> {
-    TernaryTreeRefIntoIterator { value: self, index: 0 }
+  pub fn iter(&self) -> TernaryTreeListRefIntoIterator<T> {
+    TernaryTreeListRefIntoIterator { value: self, index: 0 }
   }
-}
-
-// pass several children here
-fn decide_parent_depth_2<T: Clone + Display + Eq + PartialEq + Debug + Ord + PartialOrd + Hash>(
-  x0: &TernaryTreeList<T>,
-  x1: &TernaryTreeList<T>,
-) -> u16 {
-  cmp::max(x0.get_depth(), x1.get_depth()) + 1
-}
-
-// pass several children here
-fn decide_parent_depth_3<T: Clone + Display + Eq + PartialEq + Debug + Ord + PartialOrd + Hash>(
-  x0: &TernaryTreeList<T>,
-  x1: &TernaryTreeList<T>,
-  x2: &TernaryTreeList<T>,
-) -> u16 {
-  // println!("{} {} {}", x0.get_depth(), x1.get_depth(), x2.get_depth());
-  cmp::max(cmp::max(x0.get_depth(), x1.get_depth()), x2.get_depth()) + 1
 }
 
 impl<T> Display for TernaryTreeList<T>
@@ -1469,29 +287,32 @@ where
   T: Clone + Display + Eq + PartialEq + Debug + Ord + PartialOrd + Hash,
 {
   fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-    write!(f, "TernaryTreeList[{}, ...]", self.len())
+    match self {
+      Empty => write!(f, "Empty"),
+      Tree(t) => write!(f, "{}", t),
+    }
   }
 }
 
-// experimental code to turn `&TernaryTreeList<_>` into iterator
+// experimental code to turn `&TernaryTree<_>` into iterator
 impl<'a, T> IntoIterator for &'a TernaryTreeList<T>
 where
   T: Clone + Display + Eq + PartialEq + Debug + Ord + PartialOrd + Hash,
 {
   type Item = &'a T;
-  type IntoIter = TernaryTreeRefIntoIterator<'a, T>;
+  type IntoIter = TernaryTreeListRefIntoIterator<'a, T>;
 
   fn into_iter(self) -> Self::IntoIter {
-    TernaryTreeRefIntoIterator { value: self, index: 0 }
+    TernaryTreeListRefIntoIterator { value: self, index: 0 }
   }
 }
 
-pub struct TernaryTreeRefIntoIterator<'a, T> {
+pub struct TernaryTreeListRefIntoIterator<'a, T> {
   value: &'a TernaryTreeList<T>,
   index: usize,
 }
 
-impl<'a, T> Iterator for TernaryTreeRefIntoIterator<'a, T>
+impl<'a, T> Iterator for TernaryTreeListRefIntoIterator<'a, T>
 where
   T: Clone + Display + Eq + PartialEq + Debug + Ord + PartialOrd + Hash,
 {
@@ -1510,17 +331,11 @@ where
 
 impl<T: Clone + Display + Eq + PartialEq + Debug + Ord + PartialOrd + Hash> PartialEq for TernaryTreeList<T> {
   fn eq(&self, ys: &Self) -> bool {
-    if self.len() != ys.len() {
-      return false;
+    match (self, ys) {
+      (Empty, Empty) => true,
+      (Tree(x), Tree(y)) => x == y,
+      _ => false,
     }
-
-    for idx in 0..ys.len() {
-      if self.ref_get(idx) != ys.ref_get(idx) {
-        return false;
-      }
-    }
-
-    true
   }
 }
 
@@ -1540,17 +355,11 @@ where
   T: Clone + Display + Eq + PartialEq + Debug + Ord + PartialOrd + Hash,
 {
   fn cmp(&self, other: &Self) -> Ordering {
-    if self.len() == other.len() {
-      for idx in 0..self.len() {
-        match self.ref_get(idx).cmp(&other.ref_get(idx)) {
-          Ordering::Equal => {}
-          a => return a,
-        }
-      }
-
-      Ordering::Equal
-    } else {
-      self.len().cmp(&other.len())
+    match (self, other) {
+      (Empty, Empty) => Ordering::Equal,
+      (Empty, _) => Ordering::Less,
+      (_, Empty) => Ordering::Greater,
+      (Tree(l), Tree(r)) => l.cmp(r),
     }
   }
 }
@@ -1562,8 +371,10 @@ where
   type Output = T;
 
   fn index<'b>(&self, idx: usize) -> &Self::Output {
-    // println!("get: {} {}", self.format_inline(), idx);
-    self.ref_get(idx).expect("get from list")
+    match self {
+      Empty => panic!("index out of bounds"),
+      Tree(t) => t.ref_get(idx).expect("failed to index"),
+    }
   }
 }
 
@@ -1575,55 +386,7 @@ where
     "ternary".hash(state);
     match self {
       Empty => {}
-      Leaf(value) => {
-        "leaf".hash(state);
-        value.hash(state);
-      }
-      Branch2 { left, middle, .. } => {
-        "branch".hash(state);
-        left.hash(state);
-        middle.hash(state);
-      }
-      Branch3 { left, middle, right, .. } => {
-        "branch".hash(state);
-        left.hash(state);
-        middle.hash(state);
-        right.hash(state);
-      }
+      Tree(t) => t.hash(state),
     }
   }
-}
-
-/// internal function for mutable writing
-fn write_leaves<T>(xs: &TernaryTreeList<T>, acc: &mut Vec<TernaryTreeList<T>>, counter: &RefCell<usize>)
-where
-  T: Clone + Display + Eq + PartialEq + Debug + Ord + PartialOrd + Hash,
-{
-  if xs.is_empty() {
-    return;
-  }
-
-  match xs {
-    Empty => {}
-    Leaf { .. } => {
-      let idx = counter.take();
-      acc.push(xs.to_owned());
-
-      counter.replace(idx + 1);
-    }
-    Branch2 { left, middle, .. } => {
-      write_leaves(left, acc, counter);
-      write_leaves(middle, acc, counter);
-    }
-    Branch3 { left, middle, right, .. } => {
-      write_leaves(left, acc, counter);
-      write_leaves(middle, acc, counter);
-      write_leaves(right, acc, counter);
-    }
-  }
-}
-
-fn triple_size(t: i8) -> usize {
-  let n: usize = 3;
-  n.pow(t as u32)
 }

--- a/src/slice.rs
+++ b/src/slice.rs
@@ -2,20 +2,26 @@ use std::fmt::{Debug, Display};
 use std::hash::Hash;
 use std::sync::Arc;
 
+use crate::tree::*;
 use crate::TernaryTreeList;
-use crate::TernaryTreeList::*;
+
+use crate::tree::TernaryTree::*;
 
 impl<T> From<Vec<T>> for TernaryTreeList<T>
 where
   T: Clone + Display + Eq + PartialEq + Debug + Ord + PartialOrd + Hash,
 {
   fn from(xs: Vec<T>) -> Self {
-    let mut ys: Vec<Self> = Vec::with_capacity(xs.len());
-    for x in &xs {
-      ys.push(Leaf(Arc::new(x.to_owned())))
-    }
+    if xs.is_empty() {
+      TernaryTreeList::Empty
+    } else {
+      let mut ys: Vec<TernaryTree<T>> = Vec::with_capacity(xs.len());
+      for x in &xs {
+        ys.push(Leaf(Arc::new(x.to_owned())))
+      }
 
-    Self::rebuild_list(xs.len(), 0, &ys)
+      TernaryTreeList::Tree(TernaryTree::rebuild_list(xs.len(), 0, &ys))
+    }
   }
 }
 
@@ -24,12 +30,16 @@ where
   T: Clone + Display + Eq + PartialEq + Debug + Ord + PartialOrd + Hash,
 {
   fn from(xs: &Vec<T>) -> Self {
-    let mut ys: Vec<Self> = Vec::with_capacity(xs.len());
-    for x in xs {
-      ys.push(Leaf(Arc::new((*x).to_owned())))
-    }
+    if xs.is_empty() {
+      TernaryTreeList::Empty
+    } else {
+      let mut ys: Vec<TernaryTree<T>> = Vec::with_capacity(xs.len());
+      for x in xs {
+        ys.push(Leaf(Arc::new(x.to_owned())))
+      }
 
-    Self::rebuild_list(xs.len(), 0, &ys)
+      TernaryTreeList::Tree(TernaryTree::rebuild_list(xs.len(), 0, &ys))
+    }
   }
 }
 
@@ -39,10 +49,15 @@ where
   T: Clone + Display + Eq + PartialEq + Debug + Ord + PartialOrd + Hash,
 {
   fn from(xs: &[T; N]) -> Self {
-    let mut ys: Vec<Self> = Vec::with_capacity(xs.len());
-    for x in xs {
-      ys.push(Leaf(Arc::new((*x).to_owned())))
+    if xs.is_empty() {
+      TernaryTreeList::Empty
+    } else {
+      let mut ys: Vec<TernaryTree<T>> = Vec::with_capacity(xs.len());
+      for x in xs {
+        ys.push(Leaf(Arc::new(x.to_owned())))
+      }
+
+      TernaryTreeList::Tree(TernaryTree::rebuild_list(xs.len(), 0, &ys))
     }
-    Self::rebuild_list(xs.len(), 0, &ys)
   }
 }

--- a/src/slice.rs
+++ b/src/slice.rs
@@ -1,6 +1,5 @@
 use std::fmt::{Debug, Display};
 use std::hash::Hash;
-use std::sync::Arc;
 
 use crate::tree::*;
 use crate::TernaryTreeList;
@@ -17,7 +16,7 @@ where
     } else {
       let mut ys: Vec<TernaryTree<T>> = Vec::with_capacity(xs.len());
       for x in &xs {
-        ys.push(Leaf(Arc::new(x.to_owned())))
+        ys.push(Leaf(x.to_owned()))
       }
 
       TernaryTreeList::Tree(TernaryTree::rebuild_list(xs.len(), 0, &ys))
@@ -35,7 +34,7 @@ where
     } else {
       let mut ys: Vec<TernaryTree<T>> = Vec::with_capacity(xs.len());
       for x in xs {
-        ys.push(Leaf(Arc::new(x.to_owned())))
+        ys.push(Leaf(x.to_owned()))
       }
 
       TernaryTreeList::Tree(TernaryTree::rebuild_list(xs.len(), 0, &ys))
@@ -54,7 +53,7 @@ where
     } else {
       let mut ys: Vec<TernaryTree<T>> = Vec::with_capacity(xs.len());
       for x in xs {
-        ys.push(Leaf(Arc::new(x.to_owned())))
+        ys.push(Leaf(x.to_owned()))
       }
 
       TernaryTreeList::Tree(TernaryTree::rebuild_list(xs.len(), 0, &ys))

--- a/src/tree.rs
+++ b/src/tree.rs
@@ -11,7 +11,7 @@ use crate::util::{divide_ternary_sizes, rough_int_pow};
 
 #[derive(Clone, Debug)]
 pub enum TernaryTree<T> {
-  Leaf(Arc<T>),
+  Leaf(T),
   Branch2 {
     size: usize,
     depth: u16,
@@ -175,7 +175,7 @@ where
   pub fn index_of(&self, item: &T) -> Option<usize> {
     match self {
       Leaf(value) => {
-        if item == &**value {
+        if item == value {
           Some(0)
         } else {
           None
@@ -283,7 +283,7 @@ where
       match tree_parent {
         Leaf(value) => {
           if idx == 0 {
-            return Some((*value).to_owned());
+            return Some(value.to_owned());
           } else {
             println!("[warning] Cannot get from leaf with index {}", idx);
             return None;
@@ -355,7 +355,7 @@ where
     match self {
       Leaf { .. } => {
         if idx == 0 {
-          Ok(Leaf(Arc::new(item)))
+          Ok(Leaf(item))
         } else {
           Err(format!("Cannot assoc leaf into index {}", idx))
         }
@@ -567,13 +567,13 @@ where
             depth: 1,
             size: 2,
             left: Arc::new(self.to_owned()),
-            middle: Arc::new(Leaf(Arc::new(item))),
+            middle: Arc::new(Leaf(item)),
           })
         } else {
           Ok(Branch2 {
             depth: 1,
             size: 2,
-            left: Arc::new(Leaf(Arc::new(item))),
+            left: Arc::new(Leaf(item)),
             middle: Arc::new(self.to_owned()),
           })
         }
@@ -589,13 +589,13 @@ where
               size: 2,
               depth: 1,
               left: left.to_owned(),
-              middle: Arc::new(Leaf(Arc::new(item))),
+              middle: Arc::new(Leaf(item)),
             });
           } else {
             return Ok(Branch2 {
               size: 2,
               depth: 1,
-              left: Arc::new(Leaf(Arc::new(item))),
+              left: Arc::new(Leaf(item)),
               middle: left.to_owned(),
             });
           }
@@ -608,7 +608,7 @@ where
                 size: 3,
                 depth: 1,
                 left: left.to_owned(),
-                middle: Arc::new(Leaf(Arc::new(item))),
+                middle: Arc::new(Leaf(item)),
                 right: middle.to_owned(),
               });
             }
@@ -618,7 +618,7 @@ where
                 depth: 1,
                 left: left.to_owned(),
                 middle: middle.to_owned(),
-                right: Arc::new(Leaf(Arc::new(item))),
+                right: Arc::new(Leaf(item)),
               });
             } else {
               return Err(String::from("cannot insert after position 2 since only 2 elements here"));
@@ -627,7 +627,7 @@ where
             return Ok(Branch3 {
               size: 3,
               depth: 1,
-              left: Arc::new(Leaf(Arc::new(item))),
+              left: Arc::new(Leaf(item)),
               middle: left.to_owned(),
               right: middle.to_owned(),
             });
@@ -636,7 +636,7 @@ where
               size: 3,
               depth: 1,
               left: left.to_owned(),
-              middle: Arc::new(Leaf(Arc::new(item))),
+              middle: Arc::new(Leaf(item)),
               right: middle.to_owned(),
             });
           } else {
@@ -654,7 +654,7 @@ where
           return Ok(Branch3 {
             size: *size + 1,
             depth: *depth,
-            left: Arc::new(Leaf(Arc::new(item))),
+            left: Arc::new(Leaf(item)),
             middle: left.to_owned(),
             right: middle.to_owned(),
           });
@@ -666,7 +666,7 @@ where
             depth: *depth,
             left: left.to_owned(),
             middle: middle.to_owned(),
-            right: Arc::new(Leaf(Arc::new(item))),
+            right: Arc::new(Leaf(item)),
           });
         }
 
@@ -704,13 +704,13 @@ where
               size: 2,
               depth: 1,
               left: left.to_owned(),
-              middle: Arc::new(Leaf(Arc::new(item))),
+              middle: Arc::new(Leaf(item)),
             });
           } else {
             return Ok(Branch2 {
               size: 2,
               depth: 1,
-              left: Arc::new(Leaf(Arc::new(item))),
+              left: Arc::new(Leaf(item)),
               middle: left.to_owned(),
             });
           }
@@ -723,7 +723,7 @@ where
                 size: 3,
                 depth: 1,
                 left: left.to_owned(),
-                middle: Arc::new(Leaf(Arc::new(item))),
+                middle: Arc::new(Leaf(item)),
                 right: middle.to_owned(),
               });
             }
@@ -733,7 +733,7 @@ where
                 depth: 1,
                 left: left.to_owned(),
                 middle: middle.to_owned(),
-                right: Arc::new(Leaf(Arc::new(item))),
+                right: Arc::new(Leaf(item)),
               });
             } else {
               return Err(String::from("cannot insert after position 2 since only 2 elements here"));
@@ -742,7 +742,7 @@ where
             return Ok(Branch3 {
               size: 3,
               depth: 1,
-              left: Arc::new(Leaf(Arc::new(item))),
+              left: Arc::new(Leaf(item)),
               middle: left.to_owned(),
               right: middle.to_owned(),
             });
@@ -751,7 +751,7 @@ where
               size: 3,
               depth: 1,
               left: left.to_owned(),
-              middle: Arc::new(Leaf(Arc::new(item))),
+              middle: Arc::new(Leaf(item)),
               right: middle.to_owned(),
             });
           } else {
@@ -769,7 +769,7 @@ where
           return Ok(Branch2 {
             size: *size + 1,
             depth: depth + 1,
-            left: Arc::new(Leaf(Arc::new(item))),
+            left: Arc::new(Leaf(item)),
             middle: Arc::new(self.to_owned()),
           });
         }
@@ -779,7 +779,7 @@ where
             size: *size + 1,
             depth: depth + 1,
             left: Arc::new(self.to_owned()),
-            middle: Arc::new(Leaf(Arc::new(item))),
+            middle: Arc::new(Leaf(item)),
           });
         }
 
@@ -789,7 +789,7 @@ where
             depth: depth.to_owned(),
             left: left.to_owned(),
             middle: middle.to_owned(),
-            right: Arc::new(Leaf(Arc::new(item))),
+            right: Arc::new(Leaf(item)),
           });
         }
 
@@ -797,7 +797,7 @@ where
           return Ok(Branch3 {
             size: *size + 1,
             depth: depth.to_owned(),
-            left: Arc::new(Leaf(Arc::new(item))),
+            left: Arc::new(Leaf(item)),
             middle: left.to_owned(),
             right: middle.to_owned(),
           });
@@ -874,7 +874,7 @@ where
   }
   pub fn prepend(&self, item: T, disable_balancing: bool) -> Self {
     if self.is_empty() {
-      return Leaf(Arc::new(item));
+      return Leaf(item);
     }
 
     let mut result = match self.insert(0, item, false) {
@@ -895,7 +895,7 @@ where
   }
   pub fn append(&self, item: T, disable_balancing: bool) -> Self {
     if self.is_empty() {
-      return Leaf(Arc::new(item));
+      return Leaf(item);
     }
     let mut result = match self.insert(self.len() - 1, item, true) {
       Ok(v) => v,
@@ -1016,7 +1016,7 @@ where
 
   pub fn push_right(&self, item: T) -> Self {
     // start with 2 so its left child branch has capability of only 3^1
-    self.push_right_iter(Leaf(Arc::new(item)), FingerMark::Main(2))
+    self.push_right_iter(Leaf(item), FingerMark::Main(2))
   }
 
   pub fn drop_left(&self) -> Self {
@@ -1353,7 +1353,7 @@ where
   }
   pub fn map<V>(&self, f: Arc<dyn Fn(&T) -> V>) -> TernaryTree<V> {
     match self {
-      Leaf(value) => Leaf(Arc::new(f(value))),
+      Leaf(value) => Leaf(f(value)),
       Branch2 { left, middle, size, depth } => Branch2 {
         size: *size,
         depth: *depth,

--- a/src/tree.rs
+++ b/src/tree.rs
@@ -1,0 +1,1612 @@
+use std::cell::RefCell;
+use std::cmp;
+use std::cmp::Ordering;
+use std::fmt;
+use std::fmt::{Debug, Display};
+use std::hash::{Hash, Hasher};
+use std::ops::Index;
+use std::sync::Arc;
+
+use crate::util::{divide_ternary_sizes, rough_int_pow};
+
+#[derive(Clone, Debug)]
+pub enum TernaryTree<T> {
+  Empty,
+  Leaf(Arc<T>),
+  Branch2 {
+    size: usize,
+    depth: u16,
+    left: Arc<TernaryTree<T>>,
+    middle: Arc<TernaryTree<T>>,
+  },
+  Branch3 {
+    size: usize,
+    depth: u16,
+    left: Arc<TernaryTree<T>>,
+    middle: Arc<TernaryTree<T>>,
+    right: Arc<TernaryTree<T>>,
+  },
+}
+
+/// special mark for helping in simulating finger tree bahaviors to operate head tails
+#[derive(Debug)]
+pub enum FingerMark {
+  Main(i8),
+  Side(i8),
+}
+
+use TernaryTree::*;
+
+impl<'a, T> TernaryTree<T>
+where
+  T: Clone + Display + Eq + PartialEq + Debug + Ord + PartialOrd + Hash,
+{
+  /// just get, will not compute recursively
+  pub fn get_depth(&self) -> u16 {
+    match self {
+      Empty => 0,
+      Leaf { .. } => 0,
+      Branch2 { depth, .. } => *depth,
+      Branch3 { depth, .. } => *depth,
+    }
+  }
+
+  pub fn is_empty(&self) -> bool {
+    match self {
+      Empty => true,
+      Leaf { .. } => false,
+      Branch2 { size, .. } => *size == 0,
+      Branch3 { size, .. } => *size == 0,
+    }
+  }
+
+  pub fn len(&self) -> usize {
+    match self {
+      Empty => 0,
+      Leaf { .. } => 1,
+      Branch2 { size, .. } => *size,
+      Branch3 { size, .. } => *size,
+    }
+  }
+
+  // make list again from existed
+  pub fn rebuild_list(size: usize, offset: usize, xs: &[TernaryTree<T>]) -> Self {
+    match size {
+      0 => Empty,
+      1 => xs[offset].to_owned(),
+      2 => {
+        let left = &xs[offset];
+        let middle = &xs[offset + 1];
+        Branch2 {
+          size: left.len() + middle.len(),
+          left: Arc::new(left.to_owned()),
+          middle: Arc::new(middle.to_owned()),
+          depth: decide_parent_depth_2(left, middle),
+        }
+      }
+      3 => {
+        let left = &xs[offset];
+        let middle = &xs[offset + 1];
+        let right = &xs[offset + 2];
+        Branch3 {
+          size: left.len() + middle.len() + right.len(),
+          left: Arc::new(left.to_owned()),
+          middle: Arc::new(middle.to_owned()),
+          right: Arc::new(right.to_owned()),
+          depth: decide_parent_depth_3(left, middle, right),
+        }
+      }
+      _ => {
+        let divided = divide_ternary_sizes(size);
+
+        let left = Self::rebuild_list(divided.0, offset, xs);
+        let middle = Self::rebuild_list(divided.1, offset + divided.0, xs);
+        let right = Self::rebuild_list(divided.2, offset + divided.0 + divided.1, xs);
+        Branch3 {
+          size: left.len() + middle.len() + right.len(),
+          depth: decide_parent_depth_3(&left, &middle, &right),
+          left: Arc::new(left),
+          middle: Arc::new(middle),
+          right: Arc::new(right),
+        }
+      }
+    }
+  }
+
+  /// turn into a compare representation, with `_` for holes
+  pub fn format_inline(&self) -> String {
+    match self {
+      Empty => String::from("_"),
+      Leaf(value) => value.to_string(),
+      Branch2 { left, middle, .. } => {
+        // TODO maybe need more informations here
+        format!("({} {})", left.format_inline(), middle.format_inline())
+      }
+      Branch3 { left, middle, right, .. } => {
+        // TODO maybe need more informations here
+        format!("({} {} {})", left.format_inline(), middle.format_inline(), right.format_inline())
+      }
+    }
+  }
+
+  pub fn get(&self, idx: usize) -> Option<&T> {
+    if self.is_empty() || idx >= self.len() {
+      None
+    } else {
+      self.ref_get(idx)
+    }
+  }
+
+  pub fn find_index(&self, f: Arc<dyn Fn(&T) -> bool>) -> Option<i64> {
+    match self {
+      Empty => None,
+      Leaf(value) => {
+        if f(value) {
+          Some(0)
+        } else {
+          None
+        }
+      }
+
+      Branch2 { left, middle, .. } => {
+        if let Some(pos) = left.find_index(f.clone()) {
+          return Some(pos);
+        }
+
+        if let Some(pos) = middle.find_index(f.clone()) {
+          return Some(pos + left.len() as i64);
+        }
+
+        None
+      }
+
+      Branch3 { left, middle, right, .. } => {
+        if let Some(pos) = left.find_index(f.clone()) {
+          return Some(pos);
+        }
+
+        if let Some(pos) = middle.find_index(f.clone()) {
+          return Some(pos + left.len() as i64);
+        }
+
+        if let Some(pos) = right.find_index(f.clone()) {
+          return Some(pos + (left.len() as i64) + (middle.len() as i64));
+        }
+
+        None
+      }
+    }
+  }
+
+  pub fn index_of(&self, item: &T) -> Option<usize> {
+    match self {
+      Empty => None,
+      Leaf(value) => {
+        if item == &**value {
+          Some(0)
+        } else {
+          None
+        }
+      }
+      Branch2 { left, middle, .. } => {
+        if let Some(pos) = left.index_of(item) {
+          Some(pos)
+        } else {
+          middle.index_of(item).map(|pos| pos + left.len())
+        }
+      }
+      Branch3 { left, middle, right, .. } => {
+        if let Some(pos) = left.index_of(item) {
+          Some(pos)
+        } else if let Some(pos) = middle.index_of(item) {
+          Some(pos + left.len())
+        } else {
+          right.index_of(item).map(|pos| pos + left.len() + middle.len())
+        }
+      }
+    }
+  }
+
+  /// recursively check structure
+  pub fn is_shape_same(&self, ys: &Self) -> bool {
+    if self.is_empty() {
+      return ys.is_empty();
+    }
+
+    if ys.is_empty() {
+      return false;
+    }
+
+    if self.len() != ys.len() {
+      return false;
+    }
+
+    match (self, ys) {
+      (Leaf(value), Leaf(v2)) => value == v2,
+      (
+        Branch2 { left, middle, .. },
+        Branch2 {
+          left: left2,
+          middle: middle2,
+          ..
+        },
+      ) => left.is_shape_same(left2) && middle.is_shape_same(middle2),
+      (
+        Branch3 { left, middle, right, .. },
+        Branch3 {
+          left: left2,
+          middle: middle2,
+          right: right2,
+          ..
+        },
+      ) => left.is_shape_same(left2) && middle.is_shape_same(middle2) && right.is_shape_same(right2),
+
+      (_, _) => false,
+    }
+  }
+
+  /// internal usages for rebuilding tree
+  fn to_leaves(&self) -> Vec<TernaryTree<T>> {
+    let mut acc: Vec<TernaryTree<T>> = Vec::with_capacity(self.len());
+    let counter: RefCell<usize> = RefCell::new(0);
+    write_leaves(self, &mut acc, &counter);
+    assert_eq!(acc.len(), self.len());
+    acc
+  }
+
+  pub fn ref_get(&self, idx: usize) -> Option<&T> {
+    // println!("get: {} {}", self.format_inline(), idx);
+    // if idx >= self.len() {
+    //   println!("get from out of bound: {} {}", idx, self.len());
+    //   return None;
+    // }
+    match self {
+      Branch3 { left, middle, right, .. } => {
+        let base = left.len();
+        if idx < base {
+          left.ref_get(idx)
+        } else if idx < base + middle.len() {
+          middle.ref_get(idx - base)
+        } else {
+          right.ref_get(idx - left.len() - middle.len())
+        }
+      }
+      Branch2 { left, middle, .. } => {
+        if idx < left.len() {
+          left.ref_get(idx)
+        } else {
+          middle.ref_get(idx - left.len())
+        }
+      }
+      Leaf(value) => Some(value),
+      Empty => unreachable!("out of bound, trying to get from empty"),
+    }
+  }
+
+  /// get via go down the branch with a mutable loop
+  pub fn loop_get(&self, original_idx: usize) -> Option<T> {
+    let mut tree_parent = self.to_owned();
+    let mut idx = original_idx;
+    while tree_parent != Empty {
+      match tree_parent {
+        Empty => {
+          println!("[warning] trying to get {} from empty", idx);
+          return None;
+        }
+        Leaf(value) => {
+          if idx == 0 {
+            return Some((*value).to_owned());
+          } else {
+            println!("[warning] Cannot get from leaf with index {}", idx);
+            return None;
+          }
+        }
+        Branch2 { left, middle, size, .. } => {
+          if idx > size - 1 {
+            println!("[warning] Index too large at {} from {}", idx, size);
+            return None;
+          }
+
+          if left.len() + middle.len() != size {
+            unreachable!("tree.size does not match sum case branch sizes");
+          }
+
+          if idx < left.len() {
+            tree_parent = (*left).to_owned();
+          } else {
+            tree_parent = (*middle).to_owned();
+            idx -= left.len();
+          }
+        }
+        Branch3 {
+          left, middle, right, size, ..
+        } => {
+          if idx > size - 1 {
+            println!("[warning] Index too large at {} from {}", idx, size);
+            return None;
+          }
+
+          if left.len() + middle.len() + right.len() != size {
+            unreachable!("tree.size does not match sum case branch sizes");
+          }
+
+          if idx < left.len() {
+            tree_parent = (*left).to_owned();
+          } else if idx < left.len() + middle.len() {
+            tree_parent = (*middle).to_owned();
+            idx -= left.len();
+          } else {
+            tree_parent = (*right).to_owned();
+            idx -= left.len() + middle.len();
+          }
+        }
+      }
+    }
+
+    unreachable!("Failed to get ${idx}")
+  }
+
+  pub fn first(&self) -> Option<&T> {
+    if self.is_empty() {
+      None
+    } else {
+      self.ref_get(0)
+    }
+  }
+
+  pub fn last(&self) -> Option<&T> {
+    if self.is_empty() {
+      None
+    } else {
+      self.ref_get(self.len() - 1)
+    }
+  }
+  pub fn assoc(&self, idx: usize, item: T) -> Result<Self, String> {
+    if idx > self.len() - 1 {
+      return Err(format!("Index too large {} for {}", idx, self.format_inline()));
+    }
+
+    match self {
+      Empty => return Err(format!("Cannot assoc into empty, {}", idx)),
+      Leaf { .. } => {
+        if idx == 0 {
+          Ok(Leaf(Arc::new(item)))
+        } else {
+          Err(format!("Cannot assoc leaf into index {}", idx))
+        }
+      }
+      Branch2 { left, middle, size, .. } => {
+        if left.len() + middle.len() != *size {
+          return Err(format!(
+            "tree size {} does not match sum case branch sizes, {}",
+            size,
+            self.format_inline()
+          ));
+        }
+
+        if idx < left.len() {
+          let changed_branch = left.assoc(idx, item)?;
+          Ok(Branch2 {
+            size: size.to_owned(),
+            depth: decide_parent_depth_2(&changed_branch, middle),
+            left: Arc::new(changed_branch),
+            middle: middle.to_owned(),
+          })
+        } else {
+          let changed_branch = middle.assoc(idx - left.len(), item)?;
+          Ok(Branch2 {
+            size: size.to_owned(),
+            depth: decide_parent_depth_2(left, &changed_branch),
+            left: left.to_owned(),
+            middle: Arc::new(changed_branch),
+          })
+        }
+      }
+      Branch3 {
+        left, middle, right, size, ..
+      } => {
+        if left.len() + middle.len() + right.len() != *size {
+          return Err(format!(
+            "tree size {} does not match sum case branch sizes, {}",
+            size,
+            self.format_inline()
+          ));
+        }
+
+        if idx < left.len() {
+          let changed_branch = left.assoc(idx, item)?;
+          Ok(Branch3 {
+            size: size.to_owned(),
+            depth: decide_parent_depth_3(&changed_branch, middle, right),
+            left: Arc::new(changed_branch),
+            middle: middle.to_owned(),
+            right: right.to_owned(),
+          })
+        } else if idx < left.len() + middle.len() {
+          let changed_branch = middle.assoc(idx - left.len(), item)?;
+          Ok(Branch3 {
+            size: size.to_owned(),
+            depth: decide_parent_depth_3(left, &changed_branch, right),
+            left: left.to_owned(),
+            middle: Arc::new(changed_branch),
+            right: right.to_owned(),
+          })
+        } else {
+          let changed_branch = right.assoc(idx - left.len() - middle.len(), item)?;
+          Ok(Branch3 {
+            size: size.to_owned(),
+            depth: decide_parent_depth_3(left, middle, &changed_branch),
+            left: left.to_owned(),
+            middle: middle.to_owned(),
+            right: Arc::new(changed_branch.to_owned()),
+          })
+        }
+      }
+    }
+  }
+  pub fn dissoc(&self, idx: usize) -> Result<Self, String> {
+    if self.is_empty() {
+      return Err(String::from("Cannot remove from empty list"));
+    }
+
+    if idx > self.len() - 1 {
+      return Err(format!("Index too large {} for {}", idx, self.len()));
+    } else if self.len() == 1 {
+      // idx already == 0
+      return Ok(Empty);
+    }
+
+    match self {
+      Empty => unreachable!("dissoc out of bound"),
+      Leaf { .. } => unreachable!("dissoc should be handled at branches"),
+      Branch2 { left, middle, size, .. } => {
+        if left.len() + middle.len() != *size {
+          return Err(format!(
+            "tree {} does not match sum from branch sizes {}",
+            self.format_inline(),
+            self.len()
+          ));
+        }
+
+        if idx < left.len() {
+          if left.len() == 1 {
+            Ok((**middle).to_owned())
+          } else {
+            let changed_branch = left.dissoc(idx)?;
+            Ok(Branch2 {
+              size: *size - 1,
+              depth: decide_parent_depth_2(&changed_branch, middle),
+              left: Arc::new(changed_branch),
+              middle: middle.to_owned(),
+            })
+          }
+        } else if left.len() == 1 {
+          Ok((**left).to_owned())
+        } else {
+          let changed_branch = middle.dissoc(idx - left.len())?;
+          Ok(Branch2 {
+            size: *size - 1,
+            depth: decide_parent_depth_2(left, &changed_branch),
+            left: left.to_owned(),
+            middle: Arc::new(changed_branch),
+          })
+        }
+      }
+
+      Branch3 {
+        left, middle, right, size, ..
+      } => {
+        if left.len() + middle.len() + right.len() != *size {
+          return Err(format!(
+            "tree {} does not match sum from branch sizes {}",
+            self.format_inline(),
+            self.len()
+          ));
+        }
+
+        if idx < left.len() {
+          if left.len() == 1 {
+            Ok(Branch2 {
+              size: *size - 1,
+              depth: decide_parent_depth_2(middle, right),
+              left: middle.to_owned(),
+              middle: right.to_owned(),
+            })
+          } else {
+            let changed_branch = left.dissoc(idx)?;
+            Ok(Branch3 {
+              size: *size - 1,
+              depth: decide_parent_depth_3(&changed_branch, middle, right),
+              left: Arc::new(changed_branch),
+              middle: middle.to_owned(),
+              right: right.to_owned(),
+            })
+          }
+        } else if idx < left.len() + middle.len() {
+          if middle.len() == 1 {
+            Ok(Branch2 {
+              size: *size - 1,
+              depth: decide_parent_depth_2(left, right),
+              left: left.to_owned(),
+              middle: right.to_owned(),
+            })
+          } else {
+            let changed_branch = middle.dissoc(idx - left.len())?;
+            Ok(Branch3 {
+              size: *size - 1,
+              depth: decide_parent_depth_3(left, &changed_branch, right),
+              left: left.to_owned(),
+              middle: Arc::new(changed_branch),
+              right: right.to_owned(),
+            })
+          }
+        } else if right.len() == 1 {
+          Ok(Branch2 {
+            size: *size - 1,
+            depth: decide_parent_depth_2(left, middle),
+            left: left.to_owned(),
+            middle: middle.to_owned(),
+          })
+        } else {
+          let changed_branch = right.dissoc(idx - left.len() - middle.len())?;
+          Ok(Branch3 {
+            size: *size - 1,
+            depth: decide_parent_depth_3(left, middle, &changed_branch),
+            left: left.to_owned(),
+            middle: middle.to_owned(),
+            right: Arc::new(changed_branch.to_owned()),
+          })
+        }
+      }
+    }
+  }
+  pub fn rest(&self) -> Result<Self, String> {
+    if self.is_empty() {
+      Err(String::from("calling rest on empty"))
+    } else {
+      self.dissoc(0)
+    }
+  }
+  pub fn butlast(&self) -> Result<Self, String> {
+    if self.is_empty() {
+      Err(String::from("calling butlast on empty"))
+    } else {
+      self.dissoc(self.len() - 1)
+    }
+  }
+
+  pub fn insert(&self, idx: usize, item: T, after: bool) -> Result<Self, String> {
+    match self {
+      Empty => {
+        if idx == 0 {
+          Ok(Leaf(Arc::new(item)))
+        } else {
+          Err(format!(
+            "Empty node is not a correct position for inserting {} for {}",
+            idx,
+            self.len()
+          ))
+        }
+      }
+      Leaf { .. } => {
+        if after {
+          Ok(Branch2 {
+            depth: 1,
+            size: 2,
+            left: Arc::new(self.to_owned()),
+            middle: Arc::new(Leaf(Arc::new(item))),
+          })
+        } else {
+          Ok(Branch2 {
+            depth: 1,
+            size: 2,
+            left: Arc::new(Leaf(Arc::new(item))),
+            middle: Arc::new(self.to_owned()),
+          })
+        }
+      }
+
+      Branch2 {
+        left, middle, size, depth, ..
+      } => {
+        if self.len() == 1 {
+          if after {
+            // in compact mode, values placed at left
+            return Ok(Branch2 {
+              size: 2,
+              depth: 1,
+              left: left.to_owned(),
+              middle: Arc::new(Leaf(Arc::new(item))),
+            });
+          } else {
+            return Ok(Branch2 {
+              size: 2,
+              depth: 1,
+              left: Arc::new(Leaf(Arc::new(item))),
+              middle: left.to_owned(),
+            });
+          }
+        }
+
+        if self.len() == 2 {
+          if after {
+            if idx == 0 {
+              return Ok(Branch3 {
+                size: 3,
+                depth: 1,
+                left: left.to_owned(),
+                middle: Arc::new(Leaf(Arc::new(item))),
+                right: middle.to_owned(),
+              });
+            }
+            if idx == 1 {
+              return Ok(Branch3 {
+                size: 3,
+                depth: 1,
+                left: left.to_owned(),
+                middle: middle.to_owned(),
+                right: Arc::new(Leaf(Arc::new(item))),
+              });
+            } else {
+              return Err(String::from("cannot insert after position 2 since only 2 elements here"));
+            }
+          } else if idx == 0 {
+            return Ok(Branch3 {
+              size: 3,
+              depth: 1,
+              left: Arc::new(Leaf(Arc::new(item))),
+              middle: left.to_owned(),
+              right: middle.to_owned(),
+            });
+          } else if idx == 1 {
+            return Ok(Branch3 {
+              size: 3,
+              depth: 1,
+              left: left.to_owned(),
+              middle: Arc::new(Leaf(Arc::new(item))),
+              right: middle.to_owned(),
+            });
+          } else {
+            return Err(String::from("cannot insert before position 2 since only 2 elements here"));
+          }
+        }
+
+        if left.len() + middle.len() != *size {
+          return Err(String::from("tree.size does not match sum case branch sizes"));
+        }
+
+        // echo "picking: ", idx, " ", left.len(), " ", middle.len(), " ", right.len()
+
+        if idx == 0 && !after {
+          return Ok(Branch3 {
+            size: *size + 1,
+            depth: *depth,
+            left: Arc::new(Leaf(Arc::new(item))),
+            middle: left.to_owned(),
+            right: middle.to_owned(),
+          });
+        }
+
+        if idx == *size - 1 && after {
+          return Ok(Branch3 {
+            size: *size + 1,
+            depth: *depth,
+            left: left.to_owned(),
+            middle: middle.to_owned(),
+            right: Arc::new(Leaf(Arc::new(item))),
+          });
+        }
+
+        if idx < left.len() {
+          let changed_branch = left.insert(idx, item, after)?;
+          Ok(Branch2 {
+            size: *size + 1,
+            depth: decide_parent_depth_2(&changed_branch, middle),
+            left: Arc::new(changed_branch),
+            middle: middle.to_owned(),
+          })
+        } else {
+          let changed_branch = middle.insert(idx - left.len(), item, after)?;
+
+          Ok(Branch2 {
+            size: *size + 1,
+            depth: decide_parent_depth_2(left, &changed_branch.to_owned()),
+            left: left.to_owned(),
+            middle: Arc::new(changed_branch),
+          })
+        }
+      }
+      Branch3 {
+        left,
+        middle,
+        right,
+        size,
+        depth,
+        ..
+      } => {
+        if self.len() == 1 {
+          if after {
+            // in compact mode, values placed at left
+            return Ok(Branch2 {
+              size: 2,
+              depth: 1,
+              left: left.to_owned(),
+              middle: Arc::new(Leaf(Arc::new(item))),
+            });
+          } else {
+            return Ok(Branch2 {
+              size: 2,
+              depth: 1,
+              left: Arc::new(Leaf(Arc::new(item))),
+              middle: left.to_owned(),
+            });
+          }
+        }
+
+        if self.len() == 2 {
+          if after {
+            if idx == 0 {
+              return Ok(Branch3 {
+                size: 3,
+                depth: 1,
+                left: left.to_owned(),
+                middle: Arc::new(Leaf(Arc::new(item))),
+                right: middle.to_owned(),
+              });
+            }
+            if idx == 1 {
+              return Ok(Branch3 {
+                size: 3,
+                depth: 1,
+                left: left.to_owned(),
+                middle: middle.to_owned(),
+                right: Arc::new(Leaf(Arc::new(item))),
+              });
+            } else {
+              return Err(String::from("cannot insert after position 2 since only 2 elements here"));
+            }
+          } else if idx == 0 {
+            return Ok(Branch3 {
+              size: 3,
+              depth: 1,
+              left: Arc::new(Leaf(Arc::new(item))),
+              middle: left.to_owned(),
+              right: middle.to_owned(),
+            });
+          } else if idx == 1 {
+            return Ok(Branch3 {
+              size: 3,
+              depth: 1,
+              left: left.to_owned(),
+              middle: Arc::new(Leaf(Arc::new(item))),
+              right: middle.to_owned(),
+            });
+          } else {
+            return Err(String::from("cannot insert before position 2 since only 2 elements here"));
+          }
+        }
+
+        if left.len() + middle.len() + right.len() != *size {
+          return Err(String::from("tree.size does not match sum case branch sizes"));
+        }
+
+        // echo "picking: ", idx, " ", left.len(), " ", middle.len(), " ", right.len()
+
+        if idx == 0 && !after && left.len() >= middle.len() && left.len() >= right.len() {
+          return Ok(Branch2 {
+            size: *size + 1,
+            depth: depth + 1,
+            left: Arc::new(Leaf(Arc::new(item))),
+            middle: Arc::new(self.to_owned()),
+          });
+        }
+
+        if idx == *size - 1 && after && right.len() >= middle.len() && right.len() >= left.len() {
+          return Ok(Branch2 {
+            size: *size + 1,
+            depth: depth + 1,
+            left: Arc::new(self.to_owned()),
+            middle: Arc::new(Leaf(Arc::new(item))),
+          });
+        }
+
+        if after && idx == *size - 1 && right.len() == 0 && middle.len() >= left.len() {
+          return Ok(Branch3 {
+            size: *size + 1,
+            depth: depth.to_owned(),
+            left: left.to_owned(),
+            middle: middle.to_owned(),
+            right: Arc::new(Leaf(Arc::new(item))),
+          });
+        }
+
+        if !after && idx == 0 && right.len() == 0 && middle.len() >= right.len() {
+          return Ok(Branch3 {
+            size: *size + 1,
+            depth: depth.to_owned(),
+            left: Arc::new(Leaf(Arc::new(item))),
+            middle: left.to_owned(),
+            right: middle.to_owned(),
+          });
+        }
+
+        if idx < left.len() {
+          let changed_branch = left.insert(idx, item, after)?;
+          Ok(Branch3 {
+            size: *size + 1,
+            depth: decide_parent_depth_3(&changed_branch, middle, right),
+            left: Arc::new(changed_branch.to_owned()),
+            middle: middle.to_owned(),
+            right: right.to_owned(),
+          })
+        } else if idx < left.len() + middle.len() {
+          let changed_branch = middle.insert(idx - left.len(), item, after)?;
+
+          Ok(Branch3 {
+            size: *size + 1,
+            depth: decide_parent_depth_3(left, &changed_branch.to_owned(), right),
+            left: left.to_owned(),
+            middle: Arc::new(changed_branch.to_owned()),
+            right: right.to_owned(),
+          })
+        } else {
+          let changed_branch = right.insert(idx - left.len() - middle.len(), item, after)?;
+
+          Ok(Branch3 {
+            size: *size + 1,
+            depth: decide_parent_depth_3(left, middle, &changed_branch),
+            left: left.to_owned(),
+            middle: middle.to_owned(),
+            right: Arc::new(changed_branch.to_owned()),
+          })
+        }
+      }
+    }
+  }
+  pub fn assoc_before(&self, idx: usize, item: T) -> Result<Self, String> {
+    self.insert(idx, item, false)
+  }
+  pub fn assoc_after(&self, idx: usize, item: T) -> Result<Self, String> {
+    self.insert(idx, item, true)
+  }
+  // this function mutates original tree to make it more balanced
+  pub fn force_inplace_balancing(&mut self) -> Result<(), String> {
+    let ys = self.to_leaves();
+    *self = Self::rebuild_list(ys.len(), 0, &ys);
+    Ok(())
+  }
+  // TODO, need better strategy for detecting
+  pub fn maybe_reblance(&mut self) -> Result<(), String> {
+    match self {
+      Empty => Ok(()),
+      Leaf(..) => Ok(()),
+      Branch2 { .. } => Ok(()),
+      Branch3 { size, .. } => {
+        // guessed number
+        if *size < 81 {
+          Ok(())
+        } else {
+          let current_depth = self.get_depth();
+          if current_depth > 20 && rough_int_pow(3, current_depth - 20) > self.len() {
+            self.force_inplace_balancing()
+          } else {
+            Ok(())
+          }
+        }
+      }
+    }
+  }
+
+  pub fn unshift(&self, item: T) -> Self {
+    self.prepend(item, false)
+  }
+  pub fn prepend(&self, item: T, disable_balancing: bool) -> Self {
+    if self.is_empty() {
+      return Leaf(Arc::new(item));
+    }
+
+    let mut result = match self.insert(0, item, false) {
+      Ok(v) => v,
+      Err(e) => unreachable!(e),
+    };
+
+    if !disable_balancing {
+      if let Err(msg) = result.maybe_reblance() {
+        println!("[warning] {}", msg)
+      }
+    }
+
+    result
+  }
+  pub fn push(&self, item: T) -> Self {
+    self.append(item, false)
+  }
+  pub fn append(&self, item: T, disable_balancing: bool) -> Self {
+    if self.is_empty() {
+      return Leaf(Arc::new(item));
+    }
+    let mut result = match self.insert(self.len() - 1, item, true) {
+      Ok(v) => v,
+      Err(e) => unreachable!(e),
+    };
+
+    if !disable_balancing {
+      if let Err(msg) = result.maybe_reblance() {
+        println!("[warning] {}", msg)
+      }
+    }
+    result
+  }
+
+  fn push_right_iter(&self, item: Self, mark: FingerMark) -> Self {
+    // println!("    iter: {} {:?}", self.format_inline(), mark);
+    match mark {
+      FingerMark::Main(n) => match self {
+        Empty => item,
+        Leaf(a) => Branch2 {
+          size: 1 + item.len(),
+          depth: item.get_depth() + 1,
+          left: Arc::new(Leaf(a.to_owned())),
+          middle: Arc::new(item),
+        },
+        Branch2 { size, left, middle, .. } => {
+          if middle.len() + item.len() > left.len() || middle.len() >= triple_size(n) {
+            Branch3 {
+              size: size + item.len(),
+              depth: decide_parent_depth_3(left, middle, &item),
+              left: left.to_owned(),
+              middle: middle.to_owned(),
+              right: Arc::new(item),
+            }
+          } else {
+            let item_size = item.len();
+            let changed_branch = middle.push_right_iter(item, FingerMark::Side(n - 1));
+
+            Branch2 {
+              size: size + item_size,
+              depth: decide_parent_depth_2(left, &changed_branch),
+              left: left.to_owned(),
+              middle: Arc::new(changed_branch),
+            }
+          }
+        }
+        Branch3 {
+          size, left, middle, right, ..
+        } => {
+          if right.len() + item.len() > middle.len() || middle.len() >= triple_size(n) {
+            Branch2 {
+              size: size + item.len(),
+              depth: decide_parent_depth_2(self, &item),
+              left: Arc::new(self.to_owned()),
+              middle: Arc::new(item),
+            }
+          } else {
+            let changed_branch = right.push_right_iter(item, FingerMark::Side(n - 1));
+            Branch3 {
+              size: size + 1,
+              depth: decide_parent_depth_3(left, middle, &changed_branch),
+              left: left.to_owned(),
+              middle: middle.to_owned(),
+              right: Arc::new(changed_branch),
+            }
+          }
+        }
+      },
+      FingerMark::Side(n) => match self {
+        Empty => item,
+        Leaf(a) => Branch2 {
+          size: 1 + item.len(),
+          depth: item.get_depth() + 1,
+          left: Arc::new(Leaf(a.to_owned())),
+          middle: Arc::new(item),
+        },
+        Branch2 { size, left, middle, .. } => {
+          if middle.len() + item.len() > left.len() {
+            Branch3 {
+              size: size + item.len(),
+              depth: decide_parent_depth_3(left, middle, &item),
+              left: left.to_owned(),
+              middle: middle.to_owned(),
+              right: Arc::new(item),
+            }
+          } else {
+            let changed_branch = middle.push_right_iter(item.to_owned(), FingerMark::Side(n - 1));
+            Branch2 {
+              size: size + item.len(),
+              depth: decide_parent_depth_3(left, middle, &changed_branch),
+              left: left.to_owned(),
+              middle: Arc::new(changed_branch),
+            }
+          }
+        }
+        Branch3 {
+          size, left, middle, right, ..
+        } => {
+          if right.len() + item.len() > middle.len() {
+            Branch2 {
+              size: size + item.len(),
+              depth: decide_parent_depth_2(self, &item),
+              left: Arc::new(self.to_owned()),
+              middle: Arc::new(item),
+            }
+          } else {
+            let changed_branch = right.push_right_iter(item.to_owned(), FingerMark::Side(n - 1));
+            Branch3 {
+              size: size + item.len(),
+              depth: decide_parent_depth_3(left, middle, &changed_branch),
+              left: left.to_owned(),
+              middle: middle.to_owned(),
+              right: Arc::new(changed_branch),
+            }
+          }
+        }
+      },
+    }
+  }
+
+  pub fn push_right(&self, item: T) -> Self {
+    // start with 2 so its left child branch has capability of only 3^1
+    self.push_right_iter(Leaf(Arc::new(item)), FingerMark::Main(2))
+  }
+
+  pub fn drop_left(&self) -> Self {
+    match self {
+      Empty => unreachable!("cannot drop from empty"),
+      Leaf(_) => {
+        unreachable!("not expected empty node inside tree")
+      }
+      Branch2 { size, left, middle, .. } => {
+        if left.len() == 1 {
+          (**middle).to_owned()
+        } else {
+          let changed_branch = left.drop_left();
+          match changed_branch {
+            Empty => unreachable!("does not expect empty inside tree"),
+            Branch2 {
+              left: b_left,
+              middle: b_middle,
+              ..
+            } => Branch3 {
+              size: size - 1,
+              depth: decide_parent_depth_3(&b_left, &b_middle, middle),
+              left: b_left.to_owned(),
+              middle: b_middle.to_owned(),
+              right: middle.to_owned(),
+            },
+            Branch3 {
+              left: b_left,
+              middle: b_middle,
+              right: b_right,
+              ..
+            } => {
+              let internal_branch = Branch2 {
+                size: b_middle.len() + b_right.len(),
+                depth: decide_parent_depth_2(&b_middle, &b_right),
+                left: b_middle,
+                middle: b_right,
+              };
+              Branch3 {
+                size: size - 1,
+                depth: decide_parent_depth_3(&b_left, &internal_branch, middle),
+                left: b_left.to_owned(),
+                middle: Arc::new(internal_branch),
+                right: middle.to_owned(),
+              }
+            }
+            _ => Branch2 {
+              size: size - 1,
+              depth: decide_parent_depth_2(&changed_branch, middle),
+              left: Arc::new(changed_branch),
+              middle: middle.to_owned(),
+            },
+          }
+        }
+      }
+      Branch3 {
+        size, left, middle, right, ..
+      } => {
+        if left.len() == 1 {
+          match &**middle {
+            Empty => unreachable!("unexpected empty inside tree"),
+            Branch2 {
+              left: b_left,
+              middle: b_middle,
+              ..
+            } => Branch3 {
+              size: size - 1,
+              depth: decide_parent_depth_3(b_left, b_middle, right),
+              left: b_left.to_owned(),
+              middle: b_middle.to_owned(),
+              right: right.to_owned(),
+            },
+            Branch3 {
+              left: b_left,
+              middle: b_middle,
+              right: b_right,
+              ..
+            } => {
+              let internal_branch = Branch2 {
+                size: b_middle.len() + b_right.len(),
+                depth: decide_parent_depth_2(b_middle, b_right),
+                left: b_middle.to_owned(),
+                middle: b_right.to_owned(),
+              };
+              Branch3 {
+                size: size - 1,
+                depth: decide_parent_depth_3(b_left, &internal_branch, right),
+                left: b_left.to_owned(),
+                middle: Arc::new(internal_branch),
+                right: right.to_owned(),
+              }
+            }
+            _ => Branch2 {
+              size: size - 1,
+              depth: decide_parent_depth_2(middle, right),
+              left: middle.to_owned(),
+              middle: right.to_owned(),
+            },
+          }
+        } else {
+          let changed_branch = left.drop_left();
+          Branch3 {
+            size: size - 1,
+            depth: decide_parent_depth_3(&changed_branch, middle, right),
+            left: Arc::new(changed_branch),
+            middle: middle.to_owned(),
+            right: right.to_owned(),
+          }
+        }
+      }
+    }
+  }
+
+  pub fn concat(raw: &[TernaryTree<T>]) -> Self {
+    let mut xs_groups: Vec<TernaryTree<T>> = Vec::with_capacity(raw.len());
+    for x in raw {
+      if !x.is_empty() {
+        xs_groups.push(x.to_owned());
+      }
+    }
+    match xs_groups.len() {
+      0 => TernaryTree::Empty,
+      1 => xs_groups[0].to_owned(),
+      2 => {
+        let left = xs_groups[0].to_owned();
+        let middle = xs_groups[1].to_owned();
+        TernaryTree::Branch2 {
+          size: left.len() + middle.len(),
+          depth: decide_parent_depth_2(&left, &middle),
+          left: Arc::new(left),
+          middle: Arc::new(middle),
+        }
+      }
+      3 => {
+        let left = xs_groups[0].to_owned();
+        let middle = xs_groups[1].to_owned();
+        let right = xs_groups[2].to_owned();
+        TernaryTree::Branch3 {
+          size: left.len() + middle.len() + right.len(),
+          depth: decide_parent_depth_3(&left, &middle, &right),
+          left: Arc::new(left),
+          middle: Arc::new(middle),
+          right: Arc::new(right),
+        }
+      }
+      _ => {
+        let mut ys: Vec<TernaryTree<T>> = vec![];
+        for x in xs_groups {
+          if !x.is_empty() {
+            ys.push(x.to_owned())
+          }
+        }
+        let mut result = Self::rebuild_list(ys.len(), 0, &ys);
+        if let Err(msg) = result.maybe_reblance() {
+          println!("[warning] {}", msg)
+        }
+        result
+      }
+    }
+  }
+  pub fn check_structure(&self) -> Result<(), String> {
+    if self.is_empty() {
+      Ok(())
+    } else {
+      match self {
+        Empty => Ok(()),
+        Leaf { .. } => Ok(()),
+        Branch2 { left, middle, size, depth } => {
+          if !self.is_empty() && *size == 0 {
+            return Err(String::from("branch but has size"));
+          }
+
+          if *size != left.len() + middle.len() {
+            return Err(format!("Bad size at branch {}", self.format_inline()));
+          }
+
+          if *depth != decide_parent_depth_2(left, middle) {
+            return Err(format!("Bad depth at branch {}", self.format_inline()));
+          }
+
+          left.check_structure()?;
+          middle.check_structure()?;
+
+          Ok(())
+        }
+        Branch3 {
+          left,
+          middle,
+          right,
+          size,
+          depth,
+        } => {
+          if !self.is_empty() && *size == 0 {
+            return Err(String::from("branch but has size"));
+          }
+
+          if *size != left.len() + middle.len() + right.len() {
+            return Err(format!("Bad size at branch {}", self.format_inline()));
+          }
+
+          if *depth != decide_parent_depth_3(left, middle, right) {
+            return Err(format!("Bad depth at branch {}", self.format_inline()));
+          }
+
+          left.check_structure()?;
+          middle.check_structure()?;
+          right.check_structure()?;
+
+          Ok(())
+        }
+      }
+    }
+  }
+  // excludes value at end_idx, kept aligned with JS & Clojure
+  pub fn slice(&self, start_idx: usize, end_idx: usize) -> Result<Self, String> {
+    // echo "slice {tree.formatListInline}: {start_idx}..{end_idx}"
+    if end_idx > self.len() {
+      return Err(format!("Slice range too large {} for {}", end_idx, self.format_inline()));
+    }
+    if start_idx > end_idx {
+      return Err(format!("Invalid slice range {}..{} for {}", start_idx, end_idx, self));
+    }
+    if start_idx == end_idx {
+      return Ok(Empty);
+    }
+
+    match self {
+      Empty => return Err(format!("slicing {}..{} from empty", start_idx, end_idx)),
+      Leaf { .. } => {
+        if start_idx == 0 && end_idx == 1 {
+          Ok(self.to_owned())
+        } else {
+          Err(format!("Invalid slice range for a leaf: {} {}", start_idx, end_idx))
+        }
+      }
+
+      Branch2 { left, middle, .. } => {
+        if start_idx == 0 && end_idx == self.len() {
+          Ok(self.to_owned())
+        } else if start_idx >= left.len() {
+          // echo "sizes: {left.len()} {middle.len()} {right.len()}"
+          middle.slice(start_idx - left.len(), end_idx - left.len())
+        } else if end_idx <= left.len() {
+          left.slice(start_idx, end_idx)
+        } else {
+          let left_cut = left.slice(start_idx, left.len())?;
+          let middle_cut = middle.slice(0, end_idx - left.len())?;
+
+          Ok(TernaryTree::Branch2 {
+            size: left_cut.len() + middle_cut.len(),
+            depth: decide_parent_depth_2(&left_cut, &middle_cut),
+            left: Arc::new(left_cut),
+            middle: Arc::new(middle_cut),
+          })
+        }
+      }
+      Branch3 { left, right, middle, .. } => {
+        let base1 = left.len();
+        let base2 = base1 + middle.len();
+        if start_idx == 0 && end_idx == self.len() {
+          Ok(self.to_owned())
+        } else if start_idx >= base2 {
+          right.slice(start_idx - base2, end_idx - base2)
+        } else if start_idx >= base1 {
+          if end_idx <= base1 + middle.len() {
+            middle.slice(start_idx - base1, end_idx - base1)
+          } else {
+            let middle_cut = middle.slice(start_idx - base1, middle.len())?;
+            let right_cut = right.slice(0, end_idx - base2)?;
+
+            Ok(TernaryTree::Branch2 {
+              size: middle_cut.len() + right_cut.len(),
+              depth: decide_parent_depth_2(&middle_cut, &right_cut),
+              left: Arc::new(middle_cut),
+              middle: Arc::new(right_cut),
+            })
+          }
+        } else if end_idx <= base1 {
+          left.slice(start_idx, end_idx)
+        } else if end_idx <= base2 {
+          let left_cut = left.slice(start_idx, base1)?;
+          let middle_cut = middle.slice(0, end_idx - base1)?;
+
+          Ok(TernaryTree::Branch2 {
+            size: left_cut.len() + middle_cut.len(),
+            depth: decide_parent_depth_2(&left_cut, &middle_cut),
+            left: Arc::new(left_cut),
+            middle: Arc::new(middle_cut),
+          })
+        } else {
+          let left_cut = left.slice(start_idx, base1)?;
+          let right_cut = right.slice(0, end_idx - base2)?;
+          Ok(TernaryTree::Branch3 {
+            size: left_cut.len() + middle.len() + right_cut.len(),
+            depth: decide_parent_depth_3(&left_cut, middle, &right_cut),
+            left: Arc::new(left_cut),
+            middle: middle.clone(),
+            right: Arc::new(right_cut),
+          })
+        }
+      }
+    }
+  }
+
+  pub fn skip(&self, idx: usize) -> Result<Self, String> {
+    self.slice(idx, self.len())
+  }
+  pub fn take(&self, idx: usize) -> Result<Self, String> {
+    self.slice(0, idx)
+  }
+
+  pub fn reverse(&self) -> Self {
+    if self.is_empty() {
+      return Empty;
+    }
+
+    match self {
+      Empty => Empty,
+      Leaf { .. } => self.to_owned(),
+      Branch2 { left, middle, size, depth } => Branch2 {
+        size: *size,
+        depth: *depth,
+        left: Arc::new(middle.reverse()),
+        middle: Arc::new(left.reverse()),
+      },
+      Branch3 {
+        left,
+        middle,
+        right,
+        size,
+        depth,
+      } => Branch3 {
+        size: *size,
+        depth: *depth,
+        left: Arc::new(right.reverse()),
+        middle: Arc::new(middle.reverse()),
+        right: Arc::new(left.reverse()),
+      },
+    }
+  }
+  pub fn map<V>(&self, f: Arc<dyn Fn(&T) -> V>) -> TernaryTree<V> {
+    match self {
+      Empty => Empty,
+      Leaf(value) => Leaf(Arc::new(f(value))),
+      Branch2 { left, middle, size, depth } => Branch2 {
+        size: *size,
+        depth: *depth,
+        left: Arc::new(left.map(f.clone())),
+        middle: Arc::new(middle.map(f.clone())),
+      },
+      Branch3 {
+        left,
+        middle,
+        right,
+        size,
+        depth,
+      } => Branch3 {
+        size: *size,
+        depth: *depth,
+        left: Arc::new(left.map(f.clone())),
+        middle: Arc::new(middle.map(f.clone())),
+        right: Arc::new(right.map(f.clone())),
+      },
+    }
+  }
+
+  pub fn to_vec(&self) -> Vec<T> {
+    let mut xs = vec![];
+
+    // TODO
+    for item in self {
+      xs.push(item.to_owned());
+    }
+
+    xs
+  }
+
+  pub fn iter(&self) -> TernaryTreeRefIntoIterator<T> {
+    TernaryTreeRefIntoIterator { value: self, index: 0 }
+  }
+}
+
+// pass several children here
+fn decide_parent_depth_2<T: Clone + Display + Eq + PartialEq + Debug + Ord + PartialOrd + Hash>(
+  x0: &TernaryTree<T>,
+  x1: &TernaryTree<T>,
+) -> u16 {
+  cmp::max(x0.get_depth(), x1.get_depth()) + 1
+}
+
+// pass several children here
+fn decide_parent_depth_3<T: Clone + Display + Eq + PartialEq + Debug + Ord + PartialOrd + Hash>(
+  x0: &TernaryTree<T>,
+  x1: &TernaryTree<T>,
+  x2: &TernaryTree<T>,
+) -> u16 {
+  // println!("{} {} {}", x0.get_depth(), x1.get_depth(), x2.get_depth());
+  cmp::max(cmp::max(x0.get_depth(), x1.get_depth()), x2.get_depth()) + 1
+}
+
+impl<T> Display for TernaryTree<T>
+where
+  T: Clone + Display + Eq + PartialEq + Debug + Ord + PartialOrd + Hash,
+{
+  fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    write!(f, "TernaryTree[{}, ...]", self.len())
+  }
+}
+
+// experimental code to turn `&TernaryTree<_>` into iterator
+impl<'a, T> IntoIterator for &'a TernaryTree<T>
+where
+  T: Clone + Display + Eq + PartialEq + Debug + Ord + PartialOrd + Hash,
+{
+  type Item = &'a T;
+  type IntoIter = TernaryTreeRefIntoIterator<'a, T>;
+
+  fn into_iter(self) -> Self::IntoIter {
+    TernaryTreeRefIntoIterator { value: self, index: 0 }
+  }
+}
+
+pub struct TernaryTreeRefIntoIterator<'a, T> {
+  value: &'a TernaryTree<T>,
+  index: usize,
+}
+
+impl<'a, T> Iterator for TernaryTreeRefIntoIterator<'a, T>
+where
+  T: Clone + Display + Eq + PartialEq + Debug + Ord + PartialOrd + Hash,
+{
+  type Item = &'a T;
+  fn next(&mut self) -> Option<Self::Item> {
+    if self.index < self.value.len() {
+      // println!("get: {} {}", self.value.format_inline(), self.index);
+      let ret = self.value.ref_get(self.index);
+      self.index += 1;
+      ret
+    } else {
+      None
+    }
+  }
+}
+
+impl<T: Clone + Display + Eq + PartialEq + Debug + Ord + PartialOrd + Hash> PartialEq for TernaryTree<T> {
+  fn eq(&self, ys: &Self) -> bool {
+    if self.len() != ys.len() {
+      return false;
+    }
+
+    for idx in 0..ys.len() {
+      if self.ref_get(idx) != ys.ref_get(idx) {
+        return false;
+      }
+    }
+
+    true
+  }
+}
+
+impl<T> Eq for TernaryTree<T> where T: Clone + Display + Eq + PartialEq + Debug + Ord + PartialOrd + Hash {}
+
+impl<T> PartialOrd for TernaryTree<T>
+where
+  T: Clone + Display + Eq + PartialEq + Debug + Ord + PartialOrd + Hash,
+{
+  fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
+    Some(self.cmp(other))
+  }
+}
+
+impl<T> Ord for TernaryTree<T>
+where
+  T: Clone + Display + Eq + PartialEq + Debug + Ord + PartialOrd + Hash,
+{
+  fn cmp(&self, other: &Self) -> Ordering {
+    if self.len() == other.len() {
+      for idx in 0..self.len() {
+        match self.ref_get(idx).cmp(&other.ref_get(idx)) {
+          Ordering::Equal => {}
+          a => return a,
+        }
+      }
+
+      Ordering::Equal
+    } else {
+      self.len().cmp(&other.len())
+    }
+  }
+}
+
+impl<T> Index<usize> for TernaryTree<T>
+where
+  T: Clone + Display + Eq + PartialEq + Debug + Ord + PartialOrd + Hash,
+{
+  type Output = T;
+
+  fn index<'b>(&self, idx: usize) -> &Self::Output {
+    // println!("get: {} {}", self.format_inline(), idx);
+    self.ref_get(idx).expect("get from list")
+  }
+}
+
+impl<T> Hash for TernaryTree<T>
+where
+  T: Clone + Display + Eq + PartialEq + Debug + Ord + PartialOrd + Hash,
+{
+  fn hash<H: Hasher>(&self, state: &mut H) {
+    "ternary".hash(state);
+    match self {
+      Empty => {}
+      Leaf(value) => {
+        "leaf".hash(state);
+        value.hash(state);
+      }
+      Branch2 { left, middle, .. } => {
+        "branch".hash(state);
+        left.hash(state);
+        middle.hash(state);
+      }
+      Branch3 { left, middle, right, .. } => {
+        "branch".hash(state);
+        left.hash(state);
+        middle.hash(state);
+        right.hash(state);
+      }
+    }
+  }
+}
+
+/// internal function for mutable writing
+fn write_leaves<T>(xs: &TernaryTree<T>, acc: &mut Vec<TernaryTree<T>>, counter: &RefCell<usize>)
+where
+  T: Clone + Display + Eq + PartialEq + Debug + Ord + PartialOrd + Hash,
+{
+  if xs.is_empty() {
+    return;
+  }
+
+  match xs {
+    Empty => {}
+    Leaf { .. } => {
+      let idx = counter.take();
+      acc.push(xs.to_owned());
+
+      counter.replace(idx + 1);
+    }
+    Branch2 { left, middle, .. } => {
+      write_leaves(left, acc, counter);
+      write_leaves(middle, acc, counter);
+    }
+    Branch3 { left, middle, right, .. } => {
+      write_leaves(left, acc, counter);
+      write_leaves(middle, acc, counter);
+      write_leaves(right, acc, counter);
+    }
+  }
+}
+
+fn triple_size(t: i8) -> usize {
+  let n: usize = 3;
+  n.pow(t as u32)
+}

--- a/src/util.rs
+++ b/src/util.rs
@@ -22,7 +22,7 @@ pub fn divide_ternary_sizes(size: usize) -> (usize, usize, usize) {
   (left_size, middle_size, right_size)
 }
 
-pub fn rough_int_pow(x: usize, times: u8) -> usize {
+pub fn rough_int_pow(x: usize, times: u16) -> usize {
   if times < 1 {
     return x;
   }

--- a/tests/list_tests.rs
+++ b/tests/list_tests.rs
@@ -27,6 +27,18 @@ fn init_list() -> Result<(), String> {
 }
 
 #[test]
+fn init_list_push_right() -> Result<(), String> {
+  let mut data: Vec<usize> = vec![];
+  let mut tree: TernaryTreeList<usize> = TernaryTreeList::Empty;
+  for idx in 1..200 {
+    data.push(idx);
+    tree = tree.push_right(idx);
+    assert_eq!(tree, TernaryTreeList::from(data.to_owned()))
+  }
+  Ok(())
+}
+
+#[test]
 fn list_operations() -> Result<(), String> {
   let origin11 = &[1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11];
   let data11 = TernaryTreeList::from(origin11);
@@ -70,6 +82,24 @@ fn list_operations() -> Result<(), String> {
   assert_eq!(TernaryTreeList::from(&[1, 2, 3]).butlast()?.format_inline(), "(1 2)");
   assert_eq!(TernaryTreeList::from(&[1, 2, 3, 4]).butlast()?.format_inline(), "(1 (2 3))");
   assert_eq!(TernaryTreeList::from(&[1, 2, 3, 4, 5]).butlast()?.format_inline(), "((1 2) 3 4)");
+
+  Ok(())
+}
+
+#[test]
+fn drop_left_data() -> Result<(), String> {
+  let mut data: Vec<usize> = vec![];
+  for idx in 1..200 {
+    data.push(idx);
+  }
+  let mut tree: TernaryTreeList<usize> = TernaryTreeList::from(data.to_owned());
+
+  // do once less than the length
+  for _ in 1..data.len() {
+    tree = tree.drop_left();
+    data.remove(0);
+    assert_eq!(tree, TernaryTreeList::from(data.to_owned()));
+  }
 
   Ok(())
 }

--- a/tests/list_tests.rs
+++ b/tests/list_tests.rs
@@ -89,13 +89,13 @@ fn list_operations() -> Result<(), String> {
 #[test]
 fn drop_left_data() -> Result<(), String> {
   let mut data: Vec<usize> = vec![];
-  for idx in 1..200 {
+  for idx in 0..200 {
     data.push(idx);
   }
   let mut tree: TernaryTreeList<usize> = TernaryTreeList::from(data.to_owned());
 
   // do once less than the length
-  for _ in 1..data.len() {
+  for _ in 0..data.len() {
     tree = tree.drop_left();
     data.remove(0);
     assert_eq!(tree, TernaryTreeList::from(data.to_owned()));

--- a/tests/list_tests.rs
+++ b/tests/list_tests.rs
@@ -5,7 +5,7 @@ use std::sync::Arc;
 fn init_list() -> Result<(), String> {
   assert_eq!(
     TernaryTreeList::from(&[1, 2, 3, 4]).to_string(),
-    String::from("TernaryTreeList[4, ...]")
+    String::from("TernaryTree[4, ...]")
   );
 
   let origin11 = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11];


### PR DESCRIPTION
Based on experiences from FingerTrees, shallow branches at head and tail does help in reducing the overhead of adding/dropping elements. So I'm trying to do something similar in this library to add `.push_right` `.drop_left`. Very roughly 50% time reduced in both operations. Of cause that performance of `.drop_left` highly depends on the original structure since ternary tree is highly chaotic in its layout.

Also `Empty` is now moved out and only allowed as a variant at top level, which also decreased overhead of branching lookup.

Push right:

```
0
(0 1)
(0 1 2)
((0 1 2) 3)
((0 1 2) (3 4))
((0 1 2) (3 4 5))
((0 1 2) (3 4 5) 6)
((0 1 2) (3 4 5) (6 7))
((0 1 2) (3 4 5) (6 7 8))
(((0 1 2) (3 4 5) (6 7 8)) 9)
(((0 1 2) (3 4 5) (6 7 8)) (9 10))
(((0 1 2) (3 4 5) (6 7 8)) (9 10 11))
(((0 1 2) (3 4 5) (6 7 8)) ((9 10 11) 12))
(((0 1 2) (3 4 5) (6 7 8)) ((9 10 11) (12 13)))
(((0 1 2) (3 4 5) (6 7 8)) ((9 10 11) (12 13 14)))
(((0 1 2) (3 4 5) (6 7 8)) ((9 10 11) (12 13 14) 15))
(((0 1 2) (3 4 5) (6 7 8)) ((9 10 11) (12 13 14) (15 16)))
(((0 1 2) (3 4 5) (6 7 8)) ((9 10 11) (12 13 14) (15 16 17)))
(((0 1 2) (3 4 5) (6 7 8)) ((9 10 11) (12 13 14) (15 16 17)) 18)
((((0 1 2) (3 4 5) (6 7 8)) ((9 10 11) (12 13 14) (15 16 17)) 18) 19)
((((0 1 2) (3 4 5) (6 7 8)) ((9 10 11) (12 13 14) (15 16 17)) 18) (19 20))
((((0 1 2) (3 4 5) (6 7 8)) ((9 10 11) (12 13 14) (15 16 17)) 18) (19 20 21))
((((0 1 2) (3 4 5) (6 7 8)) ((9 10 11) (12 13 14) (15 16 17)) 18) ((19 20 21) 22))
((((0 1 2) (3 4 5) (6 7 8)) ((9 10 11) (12 13 14) (15 16 17)) 18) ((19 20 21) (22 23)))
((((0 1 2) (3 4 5) (6 7 8)) ((9 10 11) (12 13 14) (15 16 17)) 18) ((19 20 21) (22 23 24)))
((((0 1 2) (3 4 5) (6 7 8)) ((9 10 11) (12 13 14) (15 16 17)) 18) ((19 20 21) (22 23 24) 25))
((((0 1 2) (3 4 5) (6 7 8)) ((9 10 11) (12 13 14) (15 16 17)) 18) ((19 20 21) (22 23 24) (25 26)))
((((0 1 2) (3 4 5) (6 7 8)) ((9 10 11) (12 13 14) (15 16 17)) 18) ((19 20 21) (22 23 24) (25 26 27)))
((((0 1 2) (3 4 5) (6 7 8)) ((9 10 11) (12 13 14) (15 16 17)) 18) ((19 20 21) (22 23 24) (25 26 27)) 28)
(((((0 1 2) (3 4 5) (6 7 8)) ((9 10 11) (12 13 14) (15 16 17)) 18) ((19 20 21) (22 23 24) (25 26 27)) 28) 29)
(((((0 1 2) (3 4 5) (6 7 8)) ((9 10 11) (12 13 14) (15 16 17)) 18) ((19 20 21) (22 23 24) (25 26 27)) 28) (29 30))
(((((0 1 2) (3 4 5) (6 7 8)) ((9 10 11) (12 13 14) (15 16 17)) 18) ((19 20 21) (22 23 24) (25 26 27)) 28) (29 30 31))
(((((0 1 2) (3 4 5) (6 7 8)) ((9 10 11) (12 13 14) (15 16 17)) 18) ((19 20 21) (22 23 24) (25 26 27)) 28) ((29 30 31) 32))
(((((0 1 2) (3 4 5) (6 7 8)) ((9 10 11) (12 13 14) (15 16 17)) 18) ((19 20 21) (22 23 24) (25 26 27)) 28) ((29 30 31) (32 33)))
(((((0 1 2) (3 4 5) (6 7 8)) ((9 10 11) (12 13 14) (15 16 17)) 18) ((19 20 21) (22 23 24) (25 26 27)) 28) ((29 30 31) (32 33 34)))
(((((0 1 2) (3 4 5) (6 7 8)) ((9 10 11) (12 13 14) (15 16 17)) 18) ((19 20 21) (22 23 24) (25 26 27)) 28) ((29 30 31) (32 33 34) 35))
(((((0 1 2) (3 4 5) (6 7 8)) ((9 10 11) (12 13 14) (15 16 17)) 18) ((19 20 21) (22 23 24) (25 26 27)) 28) ((29 30 31) (32 33 34) (35 36)))
(((((0 1 2) (3 4 5) (6 7 8)) ((9 10 11) (12 13 14) (15 16 17)) 18) ((19 20 21) (22 23 24) (25 26 27)) 28) ((29 30 31) (32 33 34) (35 36 37)))
(((((0 1 2) (3 4 5) (6 7 8)) ((9 10 11) (12 13 14) (15 16 17)) 18) ((19 20 21) (22 23 24) (25 26 27)) 28) ((29 30 31) (32 33 34) (35 36 37)) 38)
((((((0 1 2) (3 4 5) (6 7 8)) ((9 10 11) (12 13 14) (15 16 17)) 18) ((19 20 21) (22 23 24) (25 26 27)) 28) ((29 30 31) (32 33 34) (35 36 37)) 38) 39)
((((((0 1 2) (3 4 5) (6 7 8)) ((9 10 11) (12 13 14) (15 16 17)) 18) ((19 20 21) (22 23 24) (25 26 27)) 28) ((29 30 31) (32 33 34) (35 36 37)) 38) (39 40))
((((((0 1 2) (3 4 5) (6 7 8)) ((9 10 11) (12 13 14) (15 16 17)) 18) ((19 20 21) (22 23 24) (25 26 27)) 28) ((29 30 31) (32 33 34) (35 36 37)) 38) (39 40 41))
((((((0 1 2) (3 4 5) (6 7 8)) ((9 10 11) (12 13 14) (15 16 17)) 18) ((19 20 21) (22 23 24) (25 26 27)) 28) ((29 30 31) (32 33 34) (35 36 37)) 38) ((39 40 41) 42))
((((((0 1 2) (3 4 5) (6 7 8)) ((9 10 11) (12 13 14) (15 16 17)) 18) ((19 20 21) (22 23 24) (25 26 27)) 28) ((29 30 31) (32 33 34) (35 36 37)) 38) ((39 40 41) (42 43)))
((((((0 1 2) (3 4 5) (6 7 8)) ((9 10 11) (12 13 14) (15 16 17)) 18) ((19 20 21) (22 23 24) (25 26 27)) 28) ((29 30 31) (32 33 34) (35 36 37)) 38) ((39 40 41) (42 43 44)))
((((((0 1 2) (3 4 5) (6 7 8)) ((9 10 11) (12 13 14) (15 16 17)) 18) ((19 20 21) (22 23 24) (25 26 27)) 28) ((29 30 31) (32 33 34) (35 36 37)) 38) ((39 40 41) (42 43 44) 45))
((((((0 1 2) (3 4 5) (6 7 8)) ((9 10 11) (12 13 14) (15 16 17)) 18) ((19 20 21) (22 23 24) (25 26 27)) 28) ((29 30 31) (32 33 34) (35 36 37)) 38) ((39 40 41) (42 43 44) (45 46)))
((((((0 1 2) (3 4 5) (6 7 8)) ((9 10 11) (12 13 14) (15 16 17)) 18) ((19 20 21) (22 23 24) (25 26 27)) 28) ((29 30 31) (32 33 34) (35 36 37)) 38) ((39 40 41) (42 43 44) (45 46 47)))
((((((0 1 2) (3 4 5) (6 7 8)) ((9 10 11) (12 13 14) (15 16 17)) 18) ((19 20 21) (22 23 24) (25 26 27)) 28) ((29 30 31) (32 33 34) (35 36 37)) 38) ((39 40 41) (42 43 44) (45 46 47)) 48)
(((((((0 1 2) (3 4 5) (6 7 8)) ((9 10 11) (12 13 14) (15 16 17)) 18) ((19 20 21) (22 23 24) (25 26 27)) 28) ((29 30 31) (32 33 34) (35 36 37)) 38) ((39 40 41) (42 43 44) (45 46 47)) 48) 49)
(((((((0 1 2) (3 4 5) (6 7 8)) ((9 10 11) (12 13 14) (15 16 17)) 18) ((19 20 21) (22 23 24) (25 26 27)) 28) ((29 30 31) (32 33 34) (35 36 37)) 38) ((39 40 41) (42 43 44) (45 46 47)) 48) (49 50))
(((((((0 1 2) (3 4 5) (6 7 8)) ((9 10 11) (12 13 14) (15 16 17)) 18) ((19 20 21) (22 23 24) (25 26 27)) 28) ((29 30 31) (32 33 34) (35 36 37)) 38) ((39 40 41) (42 43 44) (45 46 47)) 48) (49 50 51))
(((((((0 1 2) (3 4 5) (6 7 8)) ((9 10 11) (12 13 14) (15 16 17)) 18) ((19 20 21) (22 23 24) (25 26 27)) 28) ((29 30 31) (32 33 34) (35 36 37)) 38) ((39 40 41) (42 43 44) (45 46 47)) 48) ((49 50 51) 52))
(((((((0 1 2) (3 4 5) (6 7 8)) ((9 10 11) (12 13 14) (15 16 17)) 18) ((19 20 21) (22 23 24) (25 26 27)) 28) ((29 30 31) (32 33 34) (35 36 37)) 38) ((39 40 41) (42 43 44) (45 46 47)) 48) ((49 50 51) (52 53)))
(((((((0 1 2) (3 4 5) (6 7 8)) ((9 10 11) (12 13 14) (15 16 17)) 18) ((19 20 21) (22 23 24) (25 26 27)) 28) ((29 30 31) (32 33 34) (35 36 37)) 38) ((39 40 41) (42 43 44) (45 46 47)) 48) ((49 50 51) (52 53 54)))
(((((((0 1 2) (3 4 5) (6 7 8)) ((9 10 11) (12 13 14) (15 16 17)) 18) ((19 20 21) (22 23 24) (25 26 27)) 28) ((29 30 31) (32 33 34) (35 36 37)) 38) ((39 40 41) (42 43 44) (45 46 47)) 48) ((49 50 51) (52 53 54) 55))
(((((((0 1 2) (3 4 5) (6 7 8)) ((9 10 11) (12 13 14) (15 16 17)) 18) ((19 20 21) (22 23 24) (25 26 27)) 28) ((29 30 31) (32 33 34) (35 36 37)) 38) ((39 40 41) (42 43 44) (45 46 47)) 48) ((49 50 51) (52 53 54) (55 56)))
(((((((0 1 2) (3 4 5) (6 7 8)) ((9 10 11) (12 13 14) (15 16 17)) 18) ((19 20 21) (22 23 24) (25 26 27)) 28) ((29 30 31) (32 33 34) (35 36 37)) 38) ((39 40 41) (42 43 44) (45 46 47)) 48) ((49 50 51) (52 53 54) (55 56 57)))
(((((((0 1 2) (3 4 5) (6 7 8)) ((9 10 11) (12 13 14) (15 16 17)) 18) ((19 20 21) (22 23 24) (25 26 27)) 28) ((29 30 31) (32 33 34) (35 36 37)) 38) ((39 40 41) (42 43 44) (45 46 47)) 48) ((49 50 51) (52 53 54) (55 56 57)) 58)
((((((((0 1 2) (3 4 5) (6 7 8)) ((9 10 11) (12 13 14) (15 16 17)) 18) ((19 20 21) (22 23 24) (25 26 27)) 28) ((29 30 31) (32 33 34) (35 36 37)) 38) ((39 40 41) (42 43 44) (45 46 47)) 48) ((49 50 51) (52 53 54) (55 56 57)) 58) 59)
```

Drop left:

```
(((948 949 950) 951 ((952 953 954) 955 (956 957 958))) 959 (((((960 961 962) 963 (964 965 966)) 967 ((968 969 970) 971 (972 973 974))) 975 (((976 977 978) 979 (980 981 982)) 983 ((984 985 986) 987 (988 989 990)))) 991 (((992 993 994) 995 (996 997 998)) 999)))
(((949 950) 951 ((952 953 954) 955 (956 957 958))) 959 (((((960 961 962) 963 (964 965 966)) 967 ((968 969 970) 971 (972 973 974))) 975 (((976 977 978) 979 (980 981 982)) 983 ((984 985 986) 987 (988 989 990)))) 991 (((992 993 994) 995 (996 997 998)) 999)))
((950 951 ((952 953 954) 955 (956 957 958))) 959 (((((960 961 962) 963 (964 965 966)) 967 ((968 969 970) 971 (972 973 974))) 975 (((976 977 978) 979 (980 981 982)) 983 ((984 985 986) 987 (988 989 990)))) 991 (((992 993 994) 995 (996 997 998)) 999)))
((951 ((952 953 954) 955 (956 957 958))) 959 (((((960 961 962) 963 (964 965 966)) 967 ((968 969 970) 971 (972 973 974))) 975 (((976 977 978) 979 (980 981 982)) 983 ((984 985 986) 987 (988 989 990)))) 991 (((992 993 994) 995 (996 997 998)) 999)))
(((952 953 954) 955 (956 957 958)) 959 (((((960 961 962) 963 (964 965 966)) 967 ((968 969 970) 971 (972 973 974))) 975 (((976 977 978) 979 (980 981 982)) 983 ((984 985 986) 987 (988 989 990)))) 991 (((992 993 994) 995 (996 997 998)) 999)))
(((953 954) 955 (956 957 958)) 959 (((((960 961 962) 963 (964 965 966)) 967 ((968 969 970) 971 (972 973 974))) 975 (((976 977 978) 979 (980 981 982)) 983 ((984 985 986) 987 (988 989 990)))) 991 (((992 993 994) 995 (996 997 998)) 999)))
((954 955 (956 957 958)) 959 (((((960 961 962) 963 (964 965 966)) 967 ((968 969 970) 971 (972 973 974))) 975 (((976 977 978) 979 (980 981 982)) 983 ((984 985 986) 987 (988 989 990)))) 991 (((992 993 994) 995 (996 997 998)) 999)))
((955 (956 957 958)) 959 (((((960 961 962) 963 (964 965 966)) 967 ((968 969 970) 971 (972 973 974))) 975 (((976 977 978) 979 (980 981 982)) 983 ((984 985 986) 987 (988 989 990)))) 991 (((992 993 994) 995 (996 997 998)) 999)))
((956 957 958) 959 (((((960 961 962) 963 (964 965 966)) 967 ((968 969 970) 971 (972 973 974))) 975 (((976 977 978) 979 (980 981 982)) 983 ((984 985 986) 987 (988 989 990)))) 991 (((992 993 994) 995 (996 997 998)) 999)))
((957 958) 959 (((((960 961 962) 963 (964 965 966)) 967 ((968 969 970) 971 (972 973 974))) 975 (((976 977 978) 979 (980 981 982)) 983 ((984 985 986) 987 (988 989 990)))) 991 (((992 993 994) 995 (996 997 998)) 999)))
(958 959 (((((960 961 962) 963 (964 965 966)) 967 ((968 969 970) 971 (972 973 974))) 975 (((976 977 978) 979 (980 981 982)) 983 ((984 985 986) 987 (988 989 990)))) 991 (((992 993 994) 995 (996 997 998)) 999)))
(959 (((((960 961 962) 963 (964 965 966)) 967 ((968 969 970) 971 (972 973 974))) 975 (((976 977 978) 979 (980 981 982)) 983 ((984 985 986) 987 (988 989 990)))) 991 (((992 993 994) 995 (996 997 998)) 999)))
(((((960 961 962) 963 (964 965 966)) 967 ((968 969 970) 971 (972 973 974))) 975 (((976 977 978) 979 (980 981 982)) 983 ((984 985 986) 987 (988 989 990)))) 991 (((992 993 994) 995 (996 997 998)) 999))
(((((961 962) 963 (964 965 966)) 967 ((968 969 970) 971 (972 973 974))) 975 (((976 977 978) 979 (980 981 982)) 983 ((984 985 986) 987 (988 989 990)))) 991 (((992 993 994) 995 (996 997 998)) 999))
((((962 963 (964 965 966)) 967 ((968 969 970) 971 (972 973 974))) 975 (((976 977 978) 979 (980 981 982)) 983 ((984 985 986) 987 (988 989 990)))) 991 (((992 993 994) 995 (996 997 998)) 999))
((((963 (964 965 966)) 967 ((968 969 970) 971 (972 973 974))) 975 (((976 977 978) 979 (980 981 982)) 983 ((984 985 986) 987 (988 989 990)))) 991 (((992 993 994) 995 (996 997 998)) 999))
((((964 965 966) 967 ((968 969 970) 971 (972 973 974))) 975 (((976 977 978) 979 (980 981 982)) 983 ((984 985 986) 987 (988 989 990)))) 991 (((992 993 994) 995 (996 997 998)) 999))
((((965 966) 967 ((968 969 970) 971 (972 973 974))) 975 (((976 977 978) 979 (980 981 982)) 983 ((984 985 986) 987 (988 989 990)))) 991 (((992 993 994) 995 (996 997 998)) 999))
(((966 967 ((968 969 970) 971 (972 973 974))) 975 (((976 977 978) 979 (980 981 982)) 983 ((984 985 986) 987 (988 989 990)))) 991 (((992 993 994) 995 (996 997 998)) 999))
(((967 ((968 969 970) 971 (972 973 974))) 975 (((976 977 978) 979 (980 981 982)) 983 ((984 985 986) 987 (988 989 990)))) 991 (((992 993 994) 995 (996 997 998)) 999))
((((968 969 970) 971 (972 973 974)) 975 (((976 977 978) 979 (980 981 982)) 983 ((984 985 986) 987 (988 989 990)))) 991 (((992 993 994) 995 (996 997 998)) 999))
((((969 970) 971 (972 973 974)) 975 (((976 977 978) 979 (980 981 982)) 983 ((984 985 986) 987 (988 989 990)))) 991 (((992 993 994) 995 (996 997 998)) 999))
(((970 971 (972 973 974)) 975 (((976 977 978) 979 (980 981 982)) 983 ((984 985 986) 987 (988 989 990)))) 991 (((992 993 994) 995 (996 997 998)) 999))
(((971 (972 973 974)) 975 (((976 977 978) 979 (980 981 982)) 983 ((984 985 986) 987 (988 989 990)))) 991 (((992 993 994) 995 (996 997 998)) 999))
(((972 973 974) 975 (((976 977 978) 979 (980 981 982)) 983 ((984 985 986) 987 (988 989 990)))) 991 (((992 993 994) 995 (996 997 998)) 999))
(((973 974) 975 (((976 977 978) 979 (980 981 982)) 983 ((984 985 986) 987 (988 989 990)))) 991 (((992 993 994) 995 (996 997 998)) 999))
((974 975 (((976 977 978) 979 (980 981 982)) 983 ((984 985 986) 987 (988 989 990)))) 991 (((992 993 994) 995 (996 997 998)) 999))
((975 (((976 977 978) 979 (980 981 982)) 983 ((984 985 986) 987 (988 989 990)))) 991 (((992 993 994) 995 (996 997 998)) 999))
((((976 977 978) 979 (980 981 982)) 983 ((984 985 986) 987 (988 989 990))) 991 (((992 993 994) 995 (996 997 998)) 999))
((((977 978) 979 (980 981 982)) 983 ((984 985 986) 987 (988 989 990))) 991 (((992 993 994) 995 (996 997 998)) 999))
(((978 979 (980 981 982)) 983 ((984 985 986) 987 (988 989 990))) 991 (((992 993 994) 995 (996 997 998)) 999))
(((979 (980 981 982)) 983 ((984 985 986) 987 (988 989 990))) 991 (((992 993 994) 995 (996 997 998)) 999))
(((980 981 982) 983 ((984 985 986) 987 (988 989 990))) 991 (((992 993 994) 995 (996 997 998)) 999))
(((981 982) 983 ((984 985 986) 987 (988 989 990))) 991 (((992 993 994) 995 (996 997 998)) 999))
((982 983 ((984 985 986) 987 (988 989 990))) 991 (((992 993 994) 995 (996 997 998)) 999))
((983 ((984 985 986) 987 (988 989 990))) 991 (((992 993 994) 995 (996 997 998)) 999))
(((984 985 986) 987 (988 989 990)) 991 (((992 993 994) 995 (996 997 998)) 999))
(((985 986) 987 (988 989 990)) 991 (((992 993 994) 995 (996 997 998)) 999))
((986 987 (988 989 990)) 991 (((992 993 994) 995 (996 997 998)) 999))
((987 (988 989 990)) 991 (((992 993 994) 995 (996 997 998)) 999))
((988 989 990) 991 (((992 993 994) 995 (996 997 998)) 999))
((989 990) 991 (((992 993 994) 995 (996 997 998)) 999))
(990 991 (((992 993 994) 995 (996 997 998)) 999))
(991 (((992 993 994) 995 (996 997 998)) 999))
(((992 993 994) 995 (996 997 998)) 999)
((993 994) (995 (996 997 998)) 999)
(994 (995 (996 997 998)) 999)
(995 (996 997 998) 999)
(996 (997 998) 999)
(997 998 999)
(998 999)
999
```

A rough comparison to FingerTree:

```
    Finished bench [optimized] target(s) in 7.78s
     Running unittests (target/release/deps/ds_perf-8b76c1047a1696f5)

running 0 tests

test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s

     Running unittests (target/release/deps/perf-63ee6f925ce067ad)
WARNING: HTML report generation will become a non-default optional feature in Criterion.rs 0.4.0.
This feature is being moved to cargo-criterion (https://github.com/bheisler/cargo-criterion) and will be optional in a future version of Criterion.rs. To silence this warning, either switch to cargo-criterion or enable the 'html_reports' feature in your Cargo.toml.

Gnuplot not found, using plotters backend
ternary tree pushing    time:   [3.8072 ms 3.8724 ms 3.9553 ms]
                        change: [-0.7091% +1.4926% +4.0533%] (p = 0.23 > 0.05)
                        No change in performance detected.
Found 15 outliers among 100 measurements (15.00%)
  2 (2.00%) high mild
  13 (13.00%) high severe

finger tree pushing     time:   [6.1121 ms 6.1613 ms 6.2238 ms]
                        change: [-0.0959% +1.1011% +2.3405%] (p = 0.07 > 0.05)
                        No change in performance detected.
Found 10 outliers among 100 measurements (10.00%)
  2 (2.00%) high mild
  8 (8.00%) high severe

ternary tree init       time:   [2.5574 ms 2.5656 ms 2.5759 ms]
                        change: [-7.5446% -4.7372% -2.3178%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 8 outliers among 100 measurements (8.00%)
  5 (5.00%) high mild
  3 (3.00%) high severe

finger tree init        time:   [1.9776 ms 1.9814 ms 1.9860 ms]
                        change: [+0.1007% +0.4458% +0.7760%] (p = 0.01 < 0.05)
                        Change within noise threshold.
Found 7 outliers among 100 measurements (7.00%)
  3 (3.00%) high mild
  4 (4.00%) high severe

ternary tree rest       time:   [5.0341 ms 5.0476 ms 5.0644 ms]
                        change: [-1.1394% -0.5841% -0.0515%] (p = 0.04 < 0.05)
                        Change within noise threshold.
Found 12 outliers among 100 measurements (12.00%)
  1 (1.00%) low mild
  7 (7.00%) high mild
  4 (4.00%) high severe

finger tree rest        time:   [3.8543 ms 3.8901 ms 3.9309 ms]
                        change: [+0.3233% +1.6221% +2.9508%] (p = 0.01 < 0.05)
                        Change within noise threshold.
Found 12 outliers among 100 measurements (12.00%)
  4 (4.00%) high mild
  8 (8.00%) high severe

ternary tree access iter
                        time:   [450.65 us 453.37 us 456.99 us]
                        change: [-4.9965% -4.2309% -3.3939%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 14 outliers among 100 measurements (14.00%)
  4 (4.00%) high mild
  10 (10.00%) high severe

finger tree access iter time:   [45.597 ms 45.715 ms 45.871 ms]
                        change: [+0.1407% +0.4670% +0.8375%] (p = 0.01 < 0.05)
                        Change within noise threshold.
Found 5 outliers among 100 measurements (5.00%)
  3 (3.00%) low mild
  1 (1.00%) high mild
  1 (1.00%) high severe
```