### PR TITLE
switch back to ref_get for speed in Calcit

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 
 [package]
 name = "im_ternary_tree"
-version = "0.0.9"
+version = "0.0.10"
 edition = "2021"
 authors = ["jiyinyiyong <jiyinyiyong@gmail.com>"]
 license = "MIT"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -63,11 +63,14 @@ where
   }
 
   /// get element in list by reference
+  /// PERF: recursive function is slower than iterative loop with Cell in bench(using `usize`),
+  /// however, Calcit is heavy in cloning(reference though... according real practice),
+  /// so here we still choose `ref_get` for speed in Calcit project.
   pub fn get(&self, idx: usize) -> Option<&T> {
     if self.is_empty() || idx >= self.len() {
       None
     } else {
-      self.loop_get(idx)
+      self.ref_get(idx)
     }
   }
 
@@ -411,7 +414,7 @@ where
   fn next(&mut self) -> Option<Self::Item> {
     if self.index < self.value.len() {
       // println!("get: {} {}", self.value.format_inline(), self.index);
-      let ret = self.value.loop_get(self.index);
+      let ret = self.value.ref_get(self.index);
       self.index += 1;
       ret
     } else {
@@ -467,7 +470,7 @@ where
     } else {
       match self {
         Empty => panic!("list is empty to index"),
-        Tree(t) => t.loop_get(idx),
+        Tree(t) => t.ref_get(idx),
       }
     }
   }


### PR DESCRIPTION
尽管 `loop_get` 重构到了 `Cell` 在 benchmark 当中有惊人的提升, 但是从 Calcit 项目实际结果看, 依然用 `ref_get` 更优, 原理不明, 都是拷贝的引用, 按说应该接近一样的速度. 从 `first` `rest` 做的试验也是一样的结果, 递归函数调用更快, 用 `Cell` 手动维护会变慢(bench 未专门写). 只能认为是编译器优化对函数的情况有效.

本项目主要服务 Calcit, 以 Calcit 实际需求为依据, 还是以减少触发拷贝(即便是引用的拷贝)优先. 算法探索的结果没有真的用上, 只能作为参考和备用.
