### PR TITLE
traverse methods

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 
 [package]
 name = "im_ternary_tree"
-version = "0.0.17"
+version = "0.0.18"
 edition = "2021"
 authors = ["jiyinyiyong <jiyinyiyong@gmail.com>"]
 license = "MIT"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,7 +23,7 @@ criterion = "0.3"
 
 
 [[bench]]
-name = "accessing"
+name = "iterator"
 harness = false
 
 [profile.release]

--- a/benches/iterator.rs
+++ b/benches/iterator.rs
@@ -1,0 +1,38 @@
+use std::cell::RefCell;
+
+use criterion::{criterion_group, criterion_main, Criterion};
+
+use im_ternary_tree::TernaryTreeList;
+
+const ITER_SIZE: usize = 10000;
+
+fn criterion_benchmark(c: &mut Criterion) {
+  let mut data = TernaryTreeList::Empty;
+
+  for idx in 0..ITER_SIZE {
+    data = data.push(idx)
+  }
+
+  c.bench_function("iter", |b| {
+    let mut cc = 0;
+
+    b.iter(|| {
+      for item in &data {
+        cc += item;
+      }
+    })
+  });
+
+  c.bench_function("traverse", |b| {
+    let cc = RefCell::new(0);
+
+    b.iter(|| {
+      data.traverse(|item| {
+        *cc.borrow_mut() += item;
+      });
+    })
+  });
+}
+
+criterion_group!(benches, criterion_benchmark);
+criterion_main!(benches);

--- a/benches/iterator.rs
+++ b/benches/iterator.rs
@@ -1,5 +1,3 @@
-use std::cell::RefCell;
-
 use criterion::{criterion_group, criterion_main, Criterion};
 
 use im_ternary_tree::TernaryTreeList;
@@ -24,11 +22,11 @@ fn criterion_benchmark(c: &mut Criterion) {
   });
 
   c.bench_function("traverse", |b| {
-    let cc = RefCell::new(0);
+    let mut cc = 0;
 
     b.iter(|| {
-      data.traverse(|item| {
-        *cc.borrow_mut() += item;
+      data.traverse(&mut |item| {
+        cc += item;
       });
     })
   });

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -452,10 +452,19 @@ where
   }
 
   /// traverse all elements in list, use referenced value
-  pub fn traverse(&self, f: impl Fn(&T)) {
+  pub fn traverse(&self, f: &mut dyn FnMut(&T)) {
     match self {
       Empty => (),
-      Tree(t) => t.traverse(&f),
+      Tree(t) => t.traverse(f),
+    }
+  }
+
+  /// traverse elements in list, use referenced value,
+  /// returns `Ok` when all elements are traversed
+  pub fn traverse_result<S>(&self, f: &mut dyn FnMut(&T) -> Result<(), S>) -> Result<(), S> {
+    match self {
+      Empty => Ok(()),
+      Tree(t) => t.traverse_result(f),
     }
   }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -451,6 +451,14 @@ where
     }
   }
 
+  /// traverse all elements in list, use referenced value
+  pub fn traverse(&self, f: impl Fn(&T)) {
+    match self {
+      Empty => (),
+      Tree(t) => t.traverse(&f),
+    }
+  }
+
   pub fn iter(&self) -> TernaryTreeListRefIntoIterator<T> {
     TernaryTreeListRefIntoIterator {
       value: self,

--- a/src/tree.rs
+++ b/src/tree.rs
@@ -1240,7 +1240,7 @@ where
     xs
   }
 
-  pub fn traverse(&self, f: &impl Fn(&T)) {
+  pub fn traverse(&self, f: &mut dyn FnMut(&T)) {
     match self {
       Leaf(value) => f(value),
       Branch2 { left, middle, .. } => {
@@ -1251,6 +1251,23 @@ where
         left.traverse(f);
         middle.traverse(f);
         right.traverse(f);
+      }
+    }
+  }
+
+  pub fn traverse_result<S>(&self, f: &mut dyn FnMut(&T) -> Result<(), S>) -> Result<(), S> {
+    match self {
+      Leaf(value) => f(value),
+      Branch2 { left, middle, .. } => {
+        left.traverse_result(f)?;
+        middle.traverse_result(f)?;
+        Ok(())
+      }
+      Branch3 { left, middle, right, .. } => {
+        left.traverse_result(f)?;
+        middle.traverse_result(f)?;
+        right.traverse_result(f)?;
+        Ok(())
       }
     }
   }

--- a/src/tree.rs
+++ b/src/tree.rs
@@ -1240,8 +1240,23 @@ where
     xs
   }
 
-  pub fn iter(&self) -> TernaryTreeRefIntoIterator<T> {
-    TernaryTreeRefIntoIterator {
+  pub fn traverse(&self, f: &impl Fn(&T)) {
+    match self {
+      Leaf(value) => f(value),
+      Branch2 { left, middle, .. } => {
+        left.traverse(f);
+        middle.traverse(f);
+      }
+      Branch3 { left, middle, right, .. } => {
+        left.traverse(f);
+        middle.traverse(f);
+        right.traverse(f);
+      }
+    }
+  }
+
+  pub fn iter(&self) -> TernaryTreeIterator<T> {
+    TernaryTreeIterator {
       value: self,
       index: 0,
       size: self.len(),
@@ -1268,10 +1283,10 @@ where
   T: Clone + Display + Eq + PartialEq + Debug + Ord + PartialOrd + Hash,
 {
   type Item = &'a T;
-  type IntoIter = TernaryTreeRefIntoIterator<'a, T>;
+  type IntoIter = TernaryTreeIterator<'a, T>;
 
   fn into_iter(self) -> Self::IntoIter {
-    TernaryTreeRefIntoIterator {
+    TernaryTreeIterator {
       value: self,
       index: 0,
       size: self.len(),
@@ -1279,13 +1294,13 @@ where
   }
 }
 
-pub struct TernaryTreeRefIntoIterator<'a, T> {
+pub struct TernaryTreeIterator<'a, T> {
   value: &'a TernaryTree<T>,
   index: usize,
   size: usize,
 }
 
-impl<'a, T> Iterator for TernaryTreeRefIntoIterator<'a, T>
+impl<'a, T> Iterator for TernaryTreeIterator<'a, T>
 where
   T: Clone + Display + Eq + PartialEq + Debug + Ord + PartialOrd + Hash,
 {

--- a/tests/list_tests.rs
+++ b/tests/list_tests.rs
@@ -320,6 +320,27 @@ fn iterator() -> Result<(), String> {
 }
 
 #[test]
+fn traverse() -> Result<(), String> {
+  let origin4 = [1, 2, 3, 4];
+  let data4 = TernaryTreeList::from(&origin4);
+
+  let mut i = 0;
+  for _ in &data4 {
+    i += 1;
+  }
+
+  assert_eq!(i, 4);
+
+  i = 0;
+  for (idx, _) in data4.iter().enumerate() {
+    i += idx;
+    assert_eq!(data4.loop_get(idx).unwrap(), &origin4[idx]);
+  }
+
+  Ok(())
+}
+
+#[test]
 fn check_structure() -> Result<(), String> {
   let mut data = TernaryTreeList::from(&[]);
   for idx in 0..20 {

--- a/tests/list_tests.rs
+++ b/tests/list_tests.rs
@@ -320,7 +320,7 @@ fn iterator() -> Result<(), String> {
 }
 
 #[test]
-fn traverse() -> Result<(), String> {
+fn iter_enum() -> Result<(), String> {
   let origin4 = [1, 2, 3, 4];
   let data4 = TernaryTreeList::from(&origin4);
 
@@ -480,6 +480,49 @@ fn split_values() -> Result<(), String> {
     assert_eq!(left, data.take(i)?);
     assert_eq!(right, data.skip(i)?);
   }
+
+  Ok(())
+}
+
+#[test]
+fn traverse() -> Result<(), String> {
+  let n = 100;
+  let mut data = TernaryTreeList::from(&[]);
+  let mut total = 0;
+  for idx in 0..n {
+    data = data.append(idx);
+    total += idx;
+  }
+
+  let mut c = 0;
+
+  data.traverse(&mut |x| {
+    c += x;
+  });
+
+  assert_eq!(c, total);
+
+  Ok(())
+}
+
+#[test]
+fn traverse_result() -> Result<(), String> {
+  let n = 100;
+  let mut data = TernaryTreeList::from(&[]);
+  let mut total = 0;
+  for idx in 0..n {
+    data = data.append(idx);
+    total += idx;
+  }
+
+  let mut c = 0;
+
+  data.traverse_result::<String>(&mut |x| {
+    c += x;
+    Ok(())
+  })?;
+
+  assert_eq!(c, total);
 
   Ok(())
 }


### PR DESCRIPTION
comparing to current iterator which uses `loop_get`, `traverse_result` involved lots of branching in `Result<_, _>`, could still be slower according to results from Calcit.

<img width="773" alt="image" src="https://github.com/calcit-lang/ternary-tree.rs/assets/449224/aa4544ac-9e13-49d3-ae08-29a1f4ef462f">

